### PR TITLE
修改生成构建脚本的脚本

### DIFF
--- a/prepare.php
+++ b/prepare.php
@@ -12,6 +12,9 @@ if (!empty($argv[1])) {
     $p->setOsType(trim($argv[1]));
 }
 
+# 设置CPU核数 ; 获取CPU核数，用于 make -j $(nproc)
+$p->setMaxJob(`nproc 2> /dev/null || sysctl -n hw.ncpu`); // nproc on macos ；
+
 if ($p->osType == 'macos') {
     $p->setWorkDir(__DIR__);
     $p->setExtraLdflags('-framework CoreFoundation -framework SystemConfiguration -undefined dynamic_lookup -lwebp -licudata -licui18n -licuio');

--- a/prepare.php
+++ b/prepare.php
@@ -89,7 +89,9 @@ function install_gmp(Preprocessor $p)
 {
     $p->addLibrary(
         (new Library('gmp', '/usr/gmp'))
-            ->withUrl('https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz')
+            //站点SSL证书过期
+            //->withUrl('https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz')
+            ->withUrl('https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.lz')
             ->withConfigure('./configure --prefix=/usr/gmp --enable-static --disable-shared')
             ->withLicense('https://www.gnu.org/licenses/old-licenses/gpl-2.0.html', Library::LICENSE_GPL)
     );
@@ -135,7 +137,9 @@ function install_freetype(Preprocessor $p)
 {
     $p->addLibrary(
         (new Library('freetype', '/usr/freetype'))
-            ->withUrl('https://mirror.yongbok.net/nongnu/freetype/freetype-2.10.4.tar.gz')
+            // 域名 mirror.yongbok.net 无 DNS 解析
+            //->withUrl('https://mirror.yongbok.net/nongnu/freetype/freetype-2.10.4.tar.gz')
+            ->withUrl('https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz')
             ->withConfigure('./configure --prefix=/usr/freetype --enable-static --disable-shared')
             ->withHomePage('https://freetype.org/')
             ->withPkgName('freetype2')

--- a/prepare.php
+++ b/prepare.php
@@ -180,7 +180,7 @@ function install_bzip2(Preprocessor $p)
         (new Library('bzip2', '/usr/bzip2'))
             ->withUrl('https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz')
             ->withMakeOptions('PREFIX=/usr/bzip2')
-            ->withMakeInstallOptions('PREFIX=/usr/bzip2')
+            ->withMakeInstallOptions('install PREFIX=/usr/bzip2')
             ->withHomePage('https://www.sourceware.org/bzip2/')
             ->withLicense('https://www.sourceware.org/bzip2/', Library::LICENSE_BSD)
     );

--- a/sapi/Preprocessor.php
+++ b/sapi/Preprocessor.php
@@ -4,33 +4,43 @@ namespace SwooleCli;
 
 abstract class Project
 {
+    public const LICENSE_SPEC = 0;
+
+    public const LICENSE_APACHE2 = 1;
+
+    public const LICENSE_BSD = 2;
+
+    public const LICENSE_GPL = 3;
+
+    public const LICENSE_LGPL = 4;
+
+    public const LICENSE_MIT = 5;
+
+    public const LICENSE_PHP = 6;
+
     public string $name;
+
     public string $homePage = '';
+
     public string $license = '';
+
     public string $prefix = '';
+
     public int $licenseType = self::LICENSE_SPEC;
 
-    const LICENSE_SPEC = 0;
-    const LICENSE_APACHE2 = 1;
-    const LICENSE_BSD = 2;
-    const LICENSE_GPL = 3;
-    const LICENSE_LGPL = 4;
-    const LICENSE_MIT = 5;
-    const LICENSE_PHP = 6;
-
-    function __construct(string $name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    function withLicense(string $license, int $licenseType = self::LICENSE_SPEC): static
+    public function withLicense(string $license, int $licenseType = self::LICENSE_SPEC): static
     {
         $this->license = $license;
         $this->licenseType = $licenseType;
         return $this;
     }
 
-    function withHomePage(string $homePage): static
+    public function withHomePage(string $homePage): static
     {
         $this->homePage = $homePage;
         return $this;
@@ -40,15 +50,31 @@ abstract class Project
 class Library extends Project
 {
     public string $url;
+
+    public bool $cleanBuildDirectory = false;
+
+    public string $beforeConfigureScript = '';
+
     public string $configure = '';
+
     public string $file = '';
+
     public string $ldflags = '';
+
     public string $makeOptions = '';
+
     public string $makeInstallOptions = '';
+
+    public string $makeInstallDefaultOptions = 'install';
+
     public string $beforeInstallScript = '';
+
     public string $afterInstallScript = '';
+
     public string $pkgConfig = '';
+
     public string $pkgName = '';
+
     public string $prefix = '/usr';
 
     public function __construct(string $name, string $prefix = '/usr')
@@ -57,13 +83,13 @@ class Library extends Project
         parent::__construct($name);
     }
 
-    function withUrl(string $url): static
+    public function withUrl(string $url): static
     {
         $this->url = $url;
         return $this;
     }
 
-    function withPrefix(string $prefix): static
+    public function withPrefix(string $prefix): static
     {
         $this->prefix = $prefix;
         $this->withLdflags('-L' . $prefix . '/lib');
@@ -71,57 +97,88 @@ class Library extends Project
         return $this;
     }
 
-    function withFile(string $file): static
+    public function withFile(string $file): static
     {
         $this->file = $file;
         return $this;
     }
 
-    function withConfigure(string $configure): static
+    public function withCleanBuildDirectory(): static
+    {
+        $this->cleanBuildDirectory = true;
+        return $this;
+    }
+
+    public function withScriptBeforeConfigure(string $script): static
+    {
+        $this->beforeConfigureScript = $script;
+        return $this;
+    }
+
+    public function withConfigure(string $configure): static
     {
         $this->configure = $configure;
         return $this;
     }
 
-    function withLdflags(string $ldflags): static
+    public function withLdflags(string $ldflags): static
     {
         $this->ldflags = $ldflags;
         return $this;
     }
 
-    function withMakeOptions(string $makeOptions): static
+    public function disableDefaultLdflags(): static
+    {
+        $this->ldflags = '';
+        return $this;
+    }
+
+    public function withMakeOptions(string $makeOptions): static
     {
         $this->makeOptions = $makeOptions;
         return $this;
     }
 
-    function withScriptBeforeInstall(string $script)
+    public function withScriptBeforeInstall(string $script): static
     {
         $this->beforeInstallScript = $script;
         return $this;
     }
 
-    function withScriptAfterInstall(string $script)
+    public function withScriptAfterInstall(string $script): static
     {
         $this->afterInstallScript = $script;
         return $this;
     }
 
-    function withMakeInstallOptions(string $makeInstallOptions): static
+    public function withMakeInstallOptions(string $makeInstallOptions): static
     {
+        $this->makeInstallDefaultOptions = '';
         $this->makeInstallOptions = $makeInstallOptions;
         return $this;
     }
 
-    function withPkgConfig(string $pkgConfig): static
+    public function withPkgConfig(string $pkgConfig): static
     {
         $this->pkgConfig = $pkgConfig;
         return $this;
     }
 
-    function withPkgName(string $pkgName): static
+    public function disableDefaultPkgConfig(): static
+    {
+        $this->pkgConfig = '';
+        return $this;
+    }
+
+    public function withPkgName(string $pkgName): static
     {
         $this->pkgName = $pkgName;
+        return $this;
+    }
+
+    public function disablePkgName(): static
+    {
+        $this->pkgName = '';
         return $this;
     }
 }
@@ -129,24 +186,28 @@ class Library extends Project
 class Extension extends Project
 {
     public string $url;
+
     public string $options = '';
+
     public string $peclVersion = '';
+
     public string $file = '';
+
     public string $path = '';
 
-    function withOptions(string $options): static
+    public function withOptions(string $options): static
     {
         $this->options = $options;
         return $this;
     }
 
-    function withUrl(string $url): static
+    public function withUrl(string $url): static
     {
         $this->url = $url;
         return $this;
     }
 
-    function withPeclVersion(string $peclVersion): static
+    public function withPeclVersion(string $peclVersion): static
     {
         $this->peclVersion = $peclVersion;
         return $this;
@@ -156,14 +217,23 @@ class Extension extends Project
 class Preprocessor
 {
     public string $osType = 'linux';
+
     protected array $libraryList = [];
+
     protected array $extensionList = [];
+
     protected string $rootDir;
+
     protected string $libraryDir;
+
     protected string $extensionDir;
+
     protected array $pkgConfigPaths = [];
+
     protected string $phpSrcDir;
+
     protected string $dockerVersion = 'latest';
+
     /**
      * 指向 swoole-cli 所在的目录
      * $workDir/ext 存放扩展
@@ -171,9 +241,13 @@ class Preprocessor
      * 在 macOS 系统上，/usr 目录将会被替换为 $workDir/usr
      */
     protected string $workDir = '/work';
+
     protected string $extraLdflags = '';
+
     protected string $extraOptions = '';
+
     protected int $maxJob = 8;
+
     protected bool $installLibrary = true;
 
     /**
@@ -222,9 +296,10 @@ class Preprocessor
     ];
 
     protected array $endCallbacks = [];
+
     protected array $extCallbacks = [];
 
-    function __construct(string $rootPath)
+    public function __construct(string $rootPath)
     {
         $this->rootDir = $rootPath;
         $this->libraryDir = $rootPath . '/pool/lib';
@@ -255,57 +330,57 @@ class Preprocessor
         }
     }
 
-    function setOsType(string $osType)
+    public function setOsType(string $osType)
     {
         $this->osType = $osType;
     }
 
-    function getOsType()
+    public function getOsType()
     {
         return $this->osType;
     }
 
-    function setPhpSrcDir(string $phpSrcDir)
+    public function setPhpSrcDir(string $phpSrcDir)
     {
         $this->phpSrcDir = $phpSrcDir;
     }
 
-    function setDockerVersion(string $dockerVersion)
+    public function setDockerVersion(string $dockerVersion)
     {
         $this->dockerVersion = $dockerVersion;
     }
 
-    function setPrefix(string $prefix)
+    public function setPrefix(string $prefix)
     {
         $this->prefix = $prefix;
     }
 
-    function setWorkDir(string $workDir)
+    public function setWorkDir(string $workDir)
     {
         $this->workDir = $workDir;
     }
 
-    function getWorkDir()
+    public function getWorkDir()
     {
         return $this->workDir;
     }
 
-    function setExtraLdflags(string $flags)
+    public function setExtraLdflags(string $flags)
     {
         $this->extraLdflags = $flags;
     }
 
-    function setExtraOptions(string $options)
+    public function setExtraOptions(string $options)
     {
         $this->extraOptions = $options;
     }
 
-    function donotInstallLibrary()
+    public function donotInstallLibrary()
     {
         $this->installLibrary = false;
     }
 
-    function addLibrary(Library $lib)
+    public function addLibrary(Library $lib)
     {
         if (empty($lib->file)) {
             $lib->file = basename($lib->url);
@@ -313,10 +388,16 @@ class Preprocessor
         $skip_library_download = getenv('SKIP_LIBRARY_DOWNLOAD');
         if (empty($skip_library_download)) {
             if (!is_file($this->libraryDir . '/' . $lib->file)) {
-                echo `wget {$lib->url} -O {$this->libraryDir}/{$lib->file}`;
-                echo $lib->file;
+                echo '[Library] file downloading: ' . $lib->file . PHP_EOL . 'download url: ' . $lib->url . PHP_EOL;
+                // echo `wget {$lib->url} -O {$this->libraryDir}/{$lib->file}`;
+                echo shell_exec(
+                    "curl --connect-timeout 15 --retry 5 --retry-delay 5  -Lo {$this->libraryDir}/{$lib->file} {$lib->url}"
+                );
+                echo PHP_EOL;
+                echo 'download ' . $lib->file . ' OK ' . PHP_EOL . PHP_EOL;
+                // TODO PGP  验证
             } else {
-                echo "[Library] file cached: " . $lib->file . PHP_EOL;
+                echo '[Library] file cached: ' . $lib->file . PHP_EOL;
             }
         }
 
@@ -325,13 +406,13 @@ class Preprocessor
         }
 
         if (empty($lib->license)) {
-            throw new \RuntimeException("require license");
+            throw new \RuntimeException('require license');
         }
 
         $this->libraryList[] = $lib;
     }
 
-    function addExtension(Extension $ext)
+    public function addExtension(Extension $ext)
     {
         if ($ext->peclVersion) {
             if ($ext->peclVersion == 'latest') {
@@ -350,33 +431,33 @@ class Preprocessor
             if (!is_file($ext->path)) {
                 _download:
                 $download_name = $ext->peclVersion == 'latest' ? $ext->name : $ext->name . '-' . $ext->peclVersion;
-                echo "pecl download $download_name\n";
-                echo `cd {$this->extensionDir} && pecl download $download_name && cd -`;
+                echo "pecl download {$download_name} " . PHP_EOL;
+                echo shell_exec("cd {$this->extensionDir} && pecl download {$download_name} && cd -");
             } else {
-                echo "[Extension] file cached: " . $ext->file . PHP_EOL;
+                echo '[Extension] file cached: ' . $ext->file . PHP_EOL;
             }
 
             $dst_dir = "{$this->rootDir}/ext/{$ext->name}";
             if (!is_dir($dst_dir)) {
-                echo `mkdir -p $dst_dir`;
-                echo `tar --strip-components=1 -C $dst_dir -xf {$ext->path}`;
+                echo shell_exec("mkdir -p {$dst_dir}");
+                echo shell_exec("tar --strip-components=1 -C {$dst_dir} -xf {$ext->path}");
             }
         }
 
         $this->extensionList[] = $ext;
     }
 
-    function addEndCallback($fn)
+    public function addEndCallback($fn)
     {
         $this->endCallbacks[] = $fn;
     }
 
-    function setExtCallback($name, $fn)
+    public function setExtCallback($name, $fn)
     {
         $this->extCallbacks[$name] = $fn;
     }
 
-    function parseArguments(int $argc, array $argv)
+    public function parseArguments(int $argc, array $argv)
     {
         /**
          * Scan and load files in directory
@@ -406,7 +487,7 @@ class Preprocessor
 
         foreach ($this->extEnabled as $ext) {
             if (!isset($extAvailabled[$ext])) {
-                echo "unsupported extension[$ext]\n";
+                echo "unsupported extension[{$ext}]\n";
                 continue;
             }
             ($extAvailabled[$ext])($this);
@@ -416,7 +497,7 @@ class Preprocessor
         }
     }
 
-    function gen()
+    public function gen()
     {
         $this->pkgConfigPaths[] = '$PKG_CONFIG_PATH';
         $this->pkgConfigPaths = array_unique($this->pkgConfigPaths);
@@ -436,24 +517,23 @@ class Preprocessor
 
     /**
      * make -j {$n}
-     * @param int $n
      */
-    function setMaxJob(int $n)
+    public function setMaxJob(int $n)
     {
         $this->maxJob = $n;
     }
 
-    function info()
+    public function info()
     {
         echo '==========================================================' . PHP_EOL;
-        echo "Extension count: " . count($this->extensionList) . PHP_EOL;
+        echo 'Extension count: ' . count($this->extensionList) . PHP_EOL;
         echo '==========================================================' . PHP_EOL;
         foreach ($this->extensionList as $item) {
             echo $item->name . PHP_EOL;
         }
 
         echo '==========================================================' . PHP_EOL;
-        echo "Library count: " . count($this->libraryList) . PHP_EOL;
+        echo 'Library count: ' . count($this->libraryList) . PHP_EOL;
         echo '==========================================================' . PHP_EOL;
         foreach ($this->libraryList as $item) {
             echo "{$item->name}\n";

--- a/sapi/cli/php_cli_server.h
+++ b/sapi/cli/php_cli_server.h
@@ -25,6 +25,7 @@ extern int do_cli_server(int argc, char **argv);
 
 ZEND_BEGIN_MODULE_GLOBALS(cli_server)
 	short color;
+    zend_long log_level;
 ZEND_END_MODULE_GLOBALS(cli_server)
 
 #ifdef ZTS

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -4,6 +4,8 @@
  */
 ?>
 SRC=<?= $this->phpSrcDir . PHP_EOL ?>
+PKG_CONFIG_PATH='/usr/lib/pkgconfig'
+test -d /usr/lib64/pkgconfig && PKG_CONFIG_PATH="/usr/lib64/pkgconfig:$PKG_CONFIG_PATH" ;
 ROOT=$(pwd)
 export CC=clang
 export CXX=clang++
@@ -20,18 +22,27 @@ OPTIONS="--disable-all \
 make_<?=$item->name?>() {
     cd <?=$this->workDir?>/thirdparty
     echo "build <?=$item->name?>"
+    <?php if ($item->cleanBuildDirectory) : ?>
+        test -d <?= $this->workDir ?>/thirdparty/<?= $item->name ?> && rm -rf <?= $this->workDir ?>/thirdparty/<?= $item->name ?> ;
+    <?php endif; ?>
     mkdir -p <?=$this->workDir?>/thirdparty/<?=$item->name?> && \
     tar --strip-components=1 -C <?=$this->workDir?>/thirdparty/<?=$item->name?> -xf <?=$this->workDir?>/pool/lib/<?=$item->file?>  && \
-    cd <?=$item->name?> && \
-    echo  "<?=$item->configure?>"
+    cd <?=$item->name?> ;
+    <?php if (!empty($item->beforeConfigureScript)) : ?>
+        <?= $item->beforeConfigureScript . PHP_EOL ?>
+    <?php endif; ?>
+    :;
+    echo <<'EOF'
+    <?= $item->configure . PHP_EOL ?>
+EOF
     <?php if (!empty($item->configure)): ?>
     <?=$item->configure?> && \
     <?php endif; ?>
     make -j <?=$this->maxJob?>  <?=$item->makeOptions?> && \
-    <?php if ($item->beforeInstallScript): ?>
+    <?php if (!empty($item->beforeInstallScript)): ?>
     <?=$item->beforeInstallScript?> && \
     <?php endif; ?>
-    make install <?=$item->makeInstallOptions?> && \
+    make <?=$item->makeInstallDefaultOptions?> <?=$item->makeInstallOptions?> && \
     <?php if ($item->afterInstallScript): ?>
     <?=$item->afterInstallScript?> && \
     <?php endif; ?>

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -32,9 +32,9 @@ make_<?=$item->name?>() {
         <?= $item->beforeConfigureScript . PHP_EOL ?>
     <?php endif; ?>
     :;
-    echo <<'EOF'
+    cat <<'__EOF__'
     <?= $item->configure . PHP_EOL ?>
-EOF
+__EOF__
     <?php if (!empty($item->configure)): ?>
     <?=$item->configure?> && \
     <?php endif; ?>


### PR DESCRIPTION
## 变更
1.  新增设置CPU核数
1.  新增4个函数，功能分别是
    +  清理依赖库的构建目录
    +  依赖库在`./configure `之前执行的脚本
    + 清除默认`ldflags` 
    + 清除默认 `pkg-config`  
1.  make `install`  添加定制项，当设置`withMakeInstallOptions` 需要添加 `install`参数



## 目的：提前准备构建环境

> 使用容器的多阶段构建，把依赖库打包到容器中，提前准备好构建环境。

多阶段构建
```dockerfile
COPY --from=1 /usr/libiconv /usr/libiconv
COPY --from=1 /usr/openssl/ /usr/openssl/
COPY --from=1  /usr/brotli/ /usr/brotli/
COPY --from=1 /usr/libxml2/ /usr/libxml2/
COPY --from=1 /usr/libxslt/ /usr/libxslt/

COPY --from=1  /usr/gmp/ /usr/gmp/

COPY --from=1  /usr/zlib /usr/zlib
COPY --from=1  /usr/bzip2 /usr/bzip2
COPY --from=1  /usr/liblzma /usr/liblzma
COPY --from=1  /usr/libzstd /usr/libzstd

COPY --from=1  /usr/zip /usr/zip

COPY --from=1  /usr/giflib /usr/giflib
COPY --from=1  /usr/libpng /usr/libpng
COPY --from=1  /usr/libjpeg /usr/libjpeg
COPY --from=1  /usr/freetype /usr/freetype
COPY --from=1  /usr/libwebp /usr/libwebp

COPY --from=1  /usr/sqlite3/ /usr/sqlite3/
COPY --from=1  /usr/oniguruma/ /usr/oniguruma/

COPY --from=1  /usr/curl/ /usr/curl/

COPY --from=1  /usr/libsodium/ /usr/libsodium/
COPY --from=1  /usr/libyaml /usr/libyaml
COPY --from=1  /usr/mimalloc/ /usr/mimalloc/

COPY --from=1  /usr/imagemagick /usr/imagemagick

```

比如zip 静态库，使用 `/usr/zip `目录
![image](https://user-images.githubusercontent.com/6836228/210267847-37aa3267-adf4-453f-a44c-b4fbb8579c1a.png)

## 测试验证中发现
1.  `bzip2` 没有  `libbz2.pc` 文件，不能使用 `pkg-config` 命令，使用时需要手动指定
1. `libiconv`  不能使用 `pkg-config` 命令
1. 扩展 `mbstring ` 依赖库`oniguruma`
1. 扩展 `intl ` 依赖库 `ICU`
1. 扩展 `gd` 依赖库 `freetype` , `freetype`  依赖   `zlib bzip2 libpng  brotli `
1.  扩展'mongodb', 依赖库 `openssl`, `zlib`等


## 测试验证中，依赖库使用的pkg-name
```shell

BZIP2_CFLAGS='-I/usr/bzip2/include'
BZIP2_LIBS='-L/usr/bzip2/lib -lbz2'

export  ZLIB_CFLAGS=$(pkg-config --cflags zlib) ;
export  ZLIB_LIBS=$(pkg-config --libs zlib) ;

export LIBPNG_LIBS=$(pkg-config --cflags libpng libpng16) ;
export LIBPNG_LIBS=$(pkg-config --libs libpng libpng16) ;


LIBXML_CFLAGS=$(pkg-config --cflags libxml-2.0) ;
LIBXML_LIBS=$(pkg-config --libs libxml-2.0) ;


OPENSSL_CFLAGS=$(pkg-config --cflags openssl libcrypto libssl) ;
OPENSSL_LIBS=$(pkg-config --libs openssl libcrypto libssl) ;


SQLITE_CFLAGS=$(pkg-config --cflags sqlite3) ;
SQLITE_LIBS=$(pkg-config --libs sqlite3) ;

ZLIB_CFLAGS=$(pkg-config --cflags  zlib) ;
ZLIB_LIBS=$(pkg-config --libs  zlib) ;

CURL_CFLAGS=$(pkg-config --cflags libcurl) ;
CURL_LIBS=$(pkg-config --libs libcurl) ;

PNG_CFLAGS=$(pkg-config --cflags  libpng) ;
PNG_LIBS=$(pkg-config --libs  libpng) ;

WEBP_CFLAGS=$(pkg-config --cflags libwebp) ;
WEBP_LIBS=$(pkg-config --libs libwebp) ;

FREETYPE2_CFLAGS=$(pkg-config --cflags freetype2) ;
FREETYPE2_LIBS=$(pkg-config --libs freetype2) ;


export  ICU_CFLAGS=$(pkg-config --cflags  icu-uc icu-io icu-i18n)  ;
export  ICU_LIBS=$(pkg-config  --libs icu-uc icu-io icu-i18n)  ;

export   ONIG_CFLAGS=$(pkg-config --cflags oniguruma) ;
export   ONIG_LIBS=$(pkg-config --libs oniguruma) ;


export   LIBSODIUM_CFLAGS=$(pkg-config --cflags libsodium) ;
export   LIBSODIUM_LIBS=$(pkg-config --libs libsodium) ;

export       XSL_CFLAGS=$(pkg-config --cflags libxslt) ;
export       XSL_LIBS=$(pkg-config --libs libxslt) ;

EXSLT_CFLAGS=$(pkg-config --cflags libexslt) ;
EXSLT_LIBS=$(pkg-config --libs libexslt) ;


export    LIBZIP_CFLAGS=$(pkg-config --cflags libzip) ;
export   LIBZIP_LIBS=$(pkg-config --libs libzip) ;


#  SWOOLE_CFLAGS="$SWOOLE_CFLAGS $LIBPQ_CFLAGS"
#  SWOOLE_PGSQL_CFLAGS="$SWOOLE_CFLAGS $LIBPQ_CFLAGS"

```
