### PR TITLE
允许修改 make install 指令名称、参数（Deprecated）

### DIFF
--- a/sapi/make.php
+++ b/sapi/make.php
@@ -22,21 +22,33 @@ make_<?=$item->name?>() {
     cd <?=$this->workDir?>/thirdparty
     echo "build <?=$item->name?>"
     mkdir -p <?=$this->workDir?>/thirdparty/<?=$item->name?> && \
-    tar --strip-components=1 -C <?=$this->workDir?>/thirdparty/<?=$item->name?> -xf <?=$this->workDir?>/pool/lib/<?=$item->file?>  && \
-    cd <?=$item->name?> && \
-    echo  "<?=$item->configure?>"
+    tar --strip-components=1 -C <?=$this->workDir?>/thirdparty/<?=$item->name?> -xf <?=$this->workDir?>/pool/lib/<?=$item->file?> && \
+    cd <?=$item->name .PHP_EOL?>
     <?php if (!empty($item->configure)): ?>
-    <?=$item->configure?> && \
+cat <<'__EOF__'
+    <?= $item->configure . PHP_EOL ?>
+__EOF__
+    <?=$item->configure . PHP_EOL ?>
+    result_code=$?
+    [[ $result_code -ne 0 ]] &&  echo "[configure FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make -j <?=$this->maxJob?>  <?=$item->makeOptions?> && \
+    make -j <?=$this->maxJob?>  <?=$item->makeOptions . PHP_EOL ?>
+    result_code=$?
+    [[ $result_code -ne 0 ]] &&  echo "[make FAILURE]" && exit  $result_code;
     <?php if ($item->beforeInstallScript): ?>
-    <?=$item->beforeInstallScript?> && \
+    <?=$item->beforeInstallScript . PHP_EOL ?>
+    result_code=$?
+    [[ $result_code -ne 0 ]] &&  echo "[ before make install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make install <?=$item->makeInstallOptions?> && \
+    make install <?=$item->makeInstallOptions . PHP_EOL ?>
+    result_code=$?
+    [[ $result_code -ne 0 ]] &&  echo "[make install FAILURE]" && exit  $result_code;
     <?php if ($item->afterInstallScript): ?>
-    <?=$item->afterInstallScript?> && \
+    <?=$item->afterInstallScript . PHP_EOL ?>
+    result_code=$?
+    [[ $result_code -ne 0 ]] &&  echo "[ after make  install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    cd -
+    return 0
 }
 
 clean_<?=$item->name?>() {

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -40,7 +40,7 @@ __EOF__
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[ before make install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make install <?=$item->makeInstallOptions . PHP_EOL ?>
+    make <?= empty($item->makeInstallOptions)? "install" : $item->makeInstallOptions . PHP_EOL ?> <?= PHP_EOL ?>
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[make install FAILURE]" && exit  $result_code;
     <?php if ($item->afterInstallScript): ?>


### PR DESCRIPTION
接上一个[ 置阶段允许编写多行字符串；make 和 make install 阶段添加构建检测 ](https://github.com/swoole/swoole-cli/pull/22)PR

允许修改 make install 指令名称、参数


解决如下问题：
![image](https://user-images.githubusercontent.com/6836228/218779025-3632d80f-cda9-4cd4-b31e-d05f093f7647.png)

允许修改 make install 指令名称、参数
```bash
    make -j 8
    result_code=$?
    [[ $result_code -ne 0 ]] && echo "[make failure]" && exit $result_code;
    make  install_sw
    result_code=$?
    [[ $result_code -ne 0 ]] &&  echo "[make install failure]" && exit $result_code;


```
![image](https://user-images.githubusercontent.com/6836228/218780328-1b190d64-10e8-4ad1-a170-ec2e25d011f9.png)

