### PR TITLE
设置make install 指令名称、参数

### DIFF
--- a/sapi/Preprocessor.php
+++ b/sapi/Preprocessor.php
@@ -55,6 +55,8 @@ class Library extends Project
     public string $file = '';
     public string $ldflags = '';
     public string $makeOptions = '';
+    public string $makeInstallCommand = 'install';
+
     public string $makeInstallOptions = '';
     public string $beforeInstallScript = '';
     public string $afterInstallScript = '';
@@ -115,6 +117,12 @@ class Library extends Project
     function withScriptAfterInstall(string $script)
     {
         $this->afterInstallScript = $script;
+        return $this;
+    }
+
+    public function withMakeInstallCommand(string $makeInstallCommand): static
+    {
+        $this->makeInstallCommand = $makeInstallCommand;
         return $this;
     }
 

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -41,7 +41,7 @@ __EOF__
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[ before make install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make install <?=$item->makeInstallOptions . PHP_EOL ?>
+    make <?= $item->makeInstallCommand ?> <?= $item->makeInstallOptions ?> <?= PHP_EOL ?>
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[make install FAILURE]" && exit  $result_code;
     <?php if ($item->afterInstallScript): ?>

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -41,7 +41,7 @@ __EOF__
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[ before make install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make <?= $item->makeInstallCommand ?> <?= $item->makeInstallOptions ?> <?= PHP_EOL ?>
+    make <?= $item->makeInstallCommand ?> <?= $item->makeInstallOptions . PHP_EOL ?>
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[make install FAILURE]" && exit  $result_code;
     <?php if ($item->afterInstallScript): ?>

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -41,7 +41,7 @@ __EOF__
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[ before make install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
-    make <?= $item->makeInstallCommand ?> <?= $item->makeInstallOptions . PHP_EOL ?>
+    make <?= $item->makeInstallCommand ?> <?= $item->makeInstallOptions ?> <?= PHP_EOL ?>
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo "[make install FAILURE]" && exit  $result_code;
     <?php if ($item->afterInstallScript): ?>


### PR DESCRIPTION
设置make install 指令名称、参数

测试例子： 

>安装openssl 依赖库，直接可以缩短构建时间

```php

    $p->addLibrary((new Library('openssl'))
        ->withUrl('https://www.openssl.org/source/openssl-1.1.1p.tar.gz')
        ->withConfigure('./config' . ($p->getOsType() === 'macos' ? '' : ' -static --static') . ' no-shared --prefix=/usr/openssl')
        ->withMakeOptions('VERBOSE=1')
        ->withMakeInstallCommand('install_sw')
        ->withMakeInstallOptions('-n')
        ->withPrefix('/usr/openssl')
        ->withLicense('https://github.com/openssl/openssl/blob/master/LICENSE.txt', Library::LICENSE_APACHE2)
        ->withHomePage('https://www.openssl.org/')
    );
```