### PR TITLE
解决libxslt macOS 环境下依赖系统库libgcrypt的问题

### DIFF
--- a/conf.d/xsl.php
+++ b/conf.d/xsl.php
@@ -5,13 +5,36 @@ use SwooleCli\Preprocessor;
 use SwooleCli\Extension;
 
 return function (Preprocessor $p) {
+    $libxslt_prefix = LIBXSLT_PREFIX;
+    $libxml2_prefix = LIBXML2_PREFIX;
     $p->addLibrary(
         (new Library('libxslt'))
+            ->withHomePage('https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home')
             ->withUrl('https://gitlab.gnome.org/GNOME/libxslt/-/archive/v1.1.34/libxslt-v1.1.34.tar.gz')
-            ->withPrefix(LIBXSLT_PREFIX)
-            ->withConfigure('./autogen.sh && ./configure --prefix=' . LIBXSLT_PREFIX . ' --enable-static=yes --enable-shared=no')
+            //https://download.gnome.org/sources/libxslt/1.1/
             ->withLicense('http://www.opensource.org/licenses/mit-license.html', Library::LICENSE_MIT)
+            ->withPrefix($libxslt_prefix)
+            ->withConfigure(
+                <<<EOF
+            ./autogen.sh
+            ./configure --help
+            CPPFLAGS="$(pkg-config  --cflags-only-I  --static libxml-2.0  )" \
+            LDFLAGS="$(pkg-config --libs-only-L      --static libxml-2.0  )" \
+            LIBS="$(pkg-config --libs-only-l         --static libxml-2.0  )" \
+            ./configure \
+            --prefix={$libxslt_prefix} \
+            --enable-static=yes \
+            --enable-shared=no \
+            --with-libxml-libs-prefix={$libxml2_prefix} \
+            --without-python \
+            --without-crypto \
+            --without-profiler \
+            --without-plugins \
+            --without-debugger
+EOF
+            )
             ->withPkgName('libexslt libxslt')
+            ->withBinPath($libxslt_prefix . '/bin/')
             ->depends('libxml2', 'libiconv')
     );
     $p->addExtension((new Extension('xsl'))->withOptions('--with-xsl')->depends('libxslt'));


### PR DESCRIPTION
macOS 环境下 ，安装 libxslt  库时，会自动检测 libgcrypt-config ，一旦检测到，就会依赖上系统库。libgcrypt 同时有依赖：libgcrypt-error ，更多信息看这里：https://www.gnupg.org/documentation/manuals.html