### PR TITLE
curl 启用 nghttp2

### DIFF
--- a/conf.d/curl.php
+++ b/conf.d/curl.php
@@ -53,6 +53,48 @@ EOF
             ->withHomePage('https://c-ares.org/')
     );
 
+    $nghttp2_prefix = NGHTTP2_PREFIX;
+    $p->addLibrary(
+        (new Library('nghttp2'))
+            ->withHomePage('https://github.com/nghttp2/nghttp2.git')
+            ->withUrl('https://github.com/nghttp2/nghttp2/releases/download/v1.51.0/nghttp2-1.51.0.tar.gz')
+            ->withPrefix($nghttp2_prefix)
+            ->withConfigure(
+                <<<EOF
+            ./configure --help
+            packages="zlib libxml-2.0 libcares openssl" # jansson  libev 
+            CPPFLAGS="$(pkg-config  --cflags-only-I  --static \$packages )"  \
+            LDFLAGS="$(pkg-config --libs-only-L      --static \$packages )"  \
+            LIBS="$(pkg-config --libs-only-l         --static \$packages )"  \
+            ./configure --prefix={$nghttp2_prefix} \
+            --enable-static=yes \
+            --enable-shared=no \
+            --enable-lib-only \
+            --with-libxml2  \
+            --with-zlib \
+            --with-libcares \
+            --with-openssl \
+            --disable-http3 \
+            --disable-python-bindings  \
+            --without-jansson  \
+            --without-libevent-openssl \
+            --without-libev \
+            --without-cunit \
+            --without-jemalloc \
+            --without-mruby \
+            --without-neverbleed \
+            --without-cython \
+            --without-libngtcp2 \
+            --without-libnghttp3  \
+            --without-libbpf   \
+            --with-boost=no
+EOF
+            )
+            ->withLicense('https://github.com/nghttp2/nghttp2/blob/master/COPYING', Library::LICENSE_MIT)
+            ->withPkgName('libnghttp2')
+            ->depends('openssl', 'zlib', 'libxml2', 'cares')
+    );
+
     $curl_prefix = CURL_PREFIX;
     $openssl_prefix = OPENSSL_PREFIX;
     $zlib_prefix = ZLIB_PREFIX;
@@ -68,7 +110,7 @@ EOF
                 <<<EOF
             ./configure --help
 
-            package_name='zlib openssl libcares libbrotlicommon libbrotlidec libbrotlienc libzstd'
+            package_name='zlib openssl libcares libbrotlicommon libbrotlidec libbrotlienc libzstd libnghttp2'
             CPPFLAGS="$(pkg-config  --cflags-only-I  --static \$package_name)" \
             LDFLAGS="$(pkg-config   --libs-only-L    --static \$package_name)" \
             LIBS="$(pkg-config      --libs-only-l    --static \$package_name)" \
@@ -99,7 +141,7 @@ EOF
             --with-openssl={$openssl_prefix} \
             --enable-ares={$cares_prefix} \
             --with-default-ssl-backend=openssl \
-            --without-nghttp2 \
+            --with-nghttp2 \
             --without-ngtcp2 \
             --without-nghttp3 \
             --without-libidn2
@@ -107,7 +149,7 @@ EOF
             )
             ->withPkgName('libcurl')
             ->withBinPath($curl_prefix . '/bin/')
-            ->depends('openssl', 'cares', 'zlib', 'brotli', 'libzstd')
+            ->depends('openssl', 'cares', 'zlib', 'brotli', 'libzstd', 'nghttp2')
     );
     $p->addExtension((new Extension('curl'))->withOptions('--with-curl')->depends('curl'));
 };

--- a/conf.d/swoole.php
+++ b/conf.d/swoole.php
@@ -6,12 +6,14 @@ use SwooleCli\Extension;
 
 return function (Preprocessor $p) {
     // curl/imagemagick 对 brotli 静态库的支持有点问题，暂时关闭
-    $options = '--enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares --with-brotli-dir='. BROTLI_PREFIX;
+    $options = '--enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares ';
+    $options .= ' --with-brotli-dir=' . BROTLI_PREFIX;
+    $options .= ' --with-nghttp2-dir=' . NGHTTP2_PREFIX;
     $p->addExtension(
         (new Extension('swoole'))
-        ->withOptions($options)
-        ->withLicense('https://github.com/swoole/swoole-src/blob/master/LICENSE', Extension::LICENSE_APACHE2)
-        ->withHomePage('https://github.com/swoole/swoole-src')
-        ->depends('curl', 'openssl', 'cares', 'zlib', 'brotli')
+            ->withOptions($options)
+            ->withLicense('https://github.com/swoole/swoole-src/blob/master/LICENSE', Extension::LICENSE_APACHE2)
+            ->withHomePage('https://github.com/swoole/swoole-src')
+            ->depends('curl', 'openssl', 'cares', 'zlib', 'brotli', 'nghttp2')
     );
 };

--- a/conf.d/swoole.php
+++ b/conf.d/swoole.php
@@ -5,7 +5,6 @@ use SwooleCli\Preprocessor;
 use SwooleCli\Extension;
 
 return function (Preprocessor $p) {
-    // curl/imagemagick 对 brotli 静态库的支持有点问题，暂时关闭
     $options = '--enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares ';
     $options .= ' --with-brotli-dir=' . BROTLI_PREFIX;
     $options .= ' --with-nghttp2-dir=' . NGHTTP2_PREFIX;

--- a/sapi/constants.php
+++ b/sapi/constants.php
@@ -35,4 +35,4 @@ define("LIBZSTD_PREFIX", $p->getGlobalPrefix() . '/libzstd');
 define("LIBXLSXWRITER_PREFIX", $p->getGlobalPrefix() . '/libxlsxwriter');
 define("LIBMCRYPT_PREFIX", $p->getGlobalPrefix() . '/libmcrypt');
 define("BISON_PREFIX", $p->getGlobalPrefix() . '/bison');
-
+define("NGHTTP2_PREFIX", $p->getGlobalPrefix() . '/nghttp2');


### PR DESCRIPTION
 curl 启用 nghttp2   ; 

继续完成TODO 支持更多的库     详见： https://github.com/swoole/swoole-cli/issues/35

提示： 用了这个版本以后， swoole 如需降版本，需要停用curl 引用的nghttp2库 （因为： swoole 内置 nghttp2 库 与 curl 引用 nghttp2库  冲突；详见这里：https://github.com/swoole/swoole-cli/issues/38  ）

swoole 新增引用外部 nghttp2 库  https://github.com/swoole/swoole-cli/issues/38#issuecomment-1473304248






