### PR TITLE
1、处理shell 边界；2、禁用指定库的pkgname

### DIFF
--- a/conf.d/bison.php
+++ b/conf.d/bison.php
@@ -19,6 +19,7 @@ return function (Preprocessor $p) {
                 )
                 ->withBinPath($bison_prefix.'/bin/')
                 ->withPkgName('bision')
+                ->disablePkgNames()
         );
     }
 };

--- a/sapi/make.php
+++ b/sapi/make.php
@@ -124,6 +124,7 @@ export_variables() {
 <?php foreach ($this->varables as $name => $value) : ?>
     export <?= $name ?>="<?= $value ?>"
 <?php endforeach; ?>
+    return 0
 }
 
 make_config() {


### PR DESCRIPTION

1、处理shell 边界： 验证边界 ：
>  未修正前，看到 shell 脚本直接报错
```bash
php prepare.php \
-imagick \
-mysqli \
-zip \
-phar \
-mongodb \
-redis \
-pdo_mysql -mysqli  -mysqlnd \
-sqlite3 -pdo_sqlite \
-openssl \
-curl \
-gd -exif \
-bz2 -zlib -zip \
-pcntl  -tokenizer \
-swoole  -yaml     \
-sodium \
-gmp  -bcmath \
-phar -mbstring \
-inotify \
-ds   -posix   -soap   \
-sockets \
-intl \
-xml \
-xsl \
-iconv \
-readline
```

2、禁用指定库的pkgname
>  macOS 源码安装  `bison`  （ bision 其实是 mongodb 依赖它;安装过程中仍然需要人工干预，因为检测  `JVM ` 是否存在，暂时没有啥好的解决办法 ）

