### PR TITLE
为了调用系统库，而不是构建的依赖库

### DIFF
--- a/sapi/make.php
+++ b/sapi/make.php
@@ -11,8 +11,15 @@ ROOT=<?= $this->getRootDir() . PHP_EOL ?>
 export CC=<?= $this->cCompiler . PHP_EOL ?>
 export CXX=<?= $this->cppCompiler . PHP_EOL ?>
 export LD=<?= $this->lld . PHP_EOL ?>
+
+export SYSTEM_ORIGIN_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
 export PKG_CONFIG_PATH=<?= implode(':', $this->pkgConfigPaths) . PHP_EOL ?>
+export SWOOLE_CLI_PKG_CONFIG_PATH=$PKG_CONFIG_PATH
+
+export SYSTEM_ORIGIN_PATH=$PATH
 export PATH=<?= implode(':', $this->binPaths) . PHP_EOL ?>
+export SWOOLE_CLI_PATH=$PATH
+
 OPTIONS="--disable-all \
 --enable-shared=no \
 --enable-static=yes \


### PR DESCRIPTION
意义：  为了验证 curl 支持 http3 , 因为curl 支持 http3 有多种实现 。详情看这里： https://curl.se/docs/http3.html
其他意义： 
      1、为了 实现 php 通过  ffi  调用 opencv  。 需要构建静态的opencv （用本项目构建静态opencv ）
      2、 构建静态 ffmpeg,   从视频中取出截取图片传递给 opencv 
      3、为了让 imagemagick 支持  AV1 Image File Format 
    

例子 ：  因为   Bazel  暂时不支持 alpine 主分支（https://pkgs.alpinelinux.org/packages?name=bazel*&branch=edge&repo=testing&arch=&maintainer= ） , 最好的办法，就是通过源码构建  ； 具体信息是：  alpine 使用 musl ， Bazel 使用 glibc


使用例子
```bash

                export PATH=$SYSTEM_ORIGIN_PATH
                export PKG_CONFIG_PATH=$SYSTEM_ORIGIN_PKG_CONFIG_PATH
                # 执行构建前    
                
                # 执行构建操作
                
                # 执行构建后
                export PATH=$SWOOLE_CLI_PATH
                export PKG_CONFIG_PATH=$SWOOLE_CLI_PKG_CONFIG_PATH


```
