### PR TITLE
修复ICU 库链接icu_data  bug

### DIFF
--- a/conf.d/intl.php
+++ b/conf.d/intl.php
@@ -12,15 +12,16 @@ return function (Preprocessor $p) {
             ->withHomePage('https://icu.unicode.org/')
             ->withLicense('https://github.com/unicode-org/icu/blob/main/icu4c/LICENSE', Library::LICENSE_SPEC)
             ->withUrl('https://github.com/unicode-org/icu/releases/download/release-60-3/icu4c-60_3-src.tgz')
+            ->withManual('https://unicode-org.github.io/icu/userguide/icu_data/#:~:text=Building%20and%20Linking%20against%20ICU%20data')
+            ->withManual('https://unicode-org.github.io/icu/userguide/icu_data/#overview')
             ->withPrefix($icu_prefix)
             ->withConfigure(
                 <<<EOF
-             export CPPFLAGS="-DU_CHARSET_IS_UTF8=1  -DU_USING_ICU_NAMESPACE=1  -DU_STATIC_IMPLEMENTATION=1"
+             CPPFLAGS="-DU_CHARSET_IS_UTF8=1  -DU_USING_ICU_NAMESPACE=1  -DU_STATIC_IMPLEMENTATION=1" \
              source/runConfigureICU $os --prefix={$icu_prefix} \
-             --enable-icu-config=yes \
              --enable-static=yes \
              --enable-shared=no \
-             --with-data-packaging=archive \
+             --with-data-packaging=static \
              --enable-release=yes \
              --enable-extras=yes \
              --enable-icuio=yes \


### PR DESCRIPTION
问题现象：
![image](https://user-images.githubusercontent.com/6836228/226116047-de075615-1419-4a26-8d87-b9a9a421097c.png)


问题现象重现： 

使用编译出来的 swoole-cli 
```bash
ln -sf /home/jingjingxyk/swoole-cli/bin/swoole-cli  /usr/local/bin/php

composer update 
composer install 

```

查找问题所在： https://github.com/composer/composer/blob/c23beac9c508b701bb481d1c5269e7a2a79e0b60/src/Composer/Repository/PlatformRepository.php#L336

```php

        $cldrVersion = $this->runtime->invoke(['ResourceBundle', 'create'], ['root', 'ICUDATA', false])->get('Version');

```

解决方案： https://unicode-org.github.io/icu/userguide/icu_data/#:~:text=Building%20and%20Linking%20against%20ICU%20data

重新编译以后，验证问题，发现问题已解决：

```bash
composer update 

```