### PR TITLE
创建依赖库镜像

### DIFF
--- a/sapi/download-box/Dockerfile-dowload-box
+++ b/sapi/download-box/Dockerfile-dowload-box
@@ -1,0 +1,7 @@
+FROM    nginx:1.23-alpine
+
+RUN  rm -rf /usr/share/nginx/html/*
+ADD  ./default.conf /etc/nginx/conf.d/default.conf
+ADD  ./extensions  /usr/share/nginx/html/extensions
+ADD  ./libraries  /usr/share/nginx/html/libraries
+ADD  ./all-archive.zip  /usr/share/nginx/html/

--- a/sapi/download-box/README.md
+++ b/sapi/download-box/README.md
@@ -9,6 +9,8 @@
 
 ## 依赖库镜像验证
 
+> 本地浏览器打开地址：   [`http://0.0.0.0:8000`](http://0.0.0.0:8000)  即可查看镜像服务器
+
 ```bash 
 sh sapi/download-box/download-box-server-run.sh
 ```

--- a/sapi/download-box/README.md
+++ b/sapi/download-box/README.md
@@ -1,0 +1,33 @@
+# 创建依赖库镜像 和 使用依赖库的镜像
+
+## 依赖库镜像创建
+
+```bash 
+    sh sapi/download-box/download-box-init.sh
+    sh sapi/download-box/download-box-build.sh
+```
+
+## 依赖库镜像验证
+
+```bash 
+sh sapi/download-box/download-box-server-run.sh
+```
+
+## 依赖库镜像的分发方式
+
+1. 通过容器仓库分发
+1. 通过 web 分发
+
+## 依赖库镜像的使用
+
+### 方式一：
+
+```bash
+    sh sapi/download-box/download-box-get-archive-from-container.sh
+```
+
+### 方式二：
+
+```bash
+    sh sapi/download-box/download-box-get-archive-from-server.sh
+```

--- a/sapi/download-box/default.conf
+++ b/sapi/download-box/default.conf
@@ -23,7 +23,7 @@ server {
         autoindex_exact_size off;
         autoindex_localtime on;
 
-        default_type    text/plain;
+        default_type    application/octet-stream;
         charset utf-8;
 
     }

--- a/sapi/download-box/default.conf
+++ b/sapi/download-box/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
+    add_header Accept-Ranges bytes;
+
+    location =/robots.txt {
+         default_type text/plain;
+         add_header Content-Type "text/plain; charset=UTF-8";
+         return 200 "User-Agent: *\nAllow: /";
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+
+        autoindex on;
+        autoindex_exact_size off;
+        autoindex_localtime on;
+
+        default_type    text/plain;
+        charset utf-8;
+
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}
+

--- a/sapi/download-box/download-box-build.sh
+++ b/sapi/download-box/download-box-build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+__PROJECT__=$(
+  cd ${__DIR__}/../../
+  pwd
+)
+cd ${__PROJECT__}
+
+test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
+
+cp -f ${__DIR__}/Dockerfile-dowload-box ${__PROJECT__}/var
+cp -f ${__DIR__}/default.conf ${__PROJECT__}/var
+
+cd ${__PROJECT__}/var
+
+test -f all-archive.zip && rm -rf all-archive.zip
+
+test -d extensions && test -d libraries && zip -6 -r all-archive.zip extensions libraries
+
+cd ${__PROJECT__}/var
+
+TIME=$(date -u '+%Y%m%dT%H%M%SZ')
+VERSION="download-box-nginx-alpine-"${TIME}
+IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:${VERSION}"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-${VERSION}"
+
+docker build -t ${IMAGE} -f ./Dockerfile-dowload-box . --progress=plain
+
+docker tag ${IMAGE} ${ALIYUN_IMAGE}
+
+echo ${IMAGE} >download-box.txt
+echo ${ALIYUN_IMAGE} >download-box-aliyun.txt
+
+docker push ${ALIYUN_IMAGE}
+docker push ${IMAGE}

--- a/sapi/download-box/download-box-get-archive-from-container.sh
+++ b/sapi/download-box/download-box-get-archive-from-container.sh
@@ -14,8 +14,8 @@ cd ${__PROJECT__}
 test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
-IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230319T172427Z"
-ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230319T172427Z"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230320T064451Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230320T064451Z"
 
 cd ${__PROJECT__}/var
 

--- a/sapi/download-box/download-box-get-archive-from-container.sh
+++ b/sapi/download-box/download-box-get-archive-from-container.sh
@@ -14,8 +14,8 @@ cd ${__PROJECT__}
 test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
-IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230318T184831Z"
-ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230318T184831Z"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230319T172427Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230319T172427Z"
 
 cd ${__PROJECT__}/var
 

--- a/sapi/download-box/download-box-get-archive-from-container.sh
+++ b/sapi/download-box/download-box-get-archive-from-container.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+__PROJECT__=$(
+  cd ${__DIR__}/../../
+  pwd
+)
+cd ${__PROJECT__}
+
+test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
+
+IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230318T184831Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230318T184831Z"
+
+cd ${__PROJECT__}/var
+
+test -f download-box.txt && IMAGE=$(head -n 1 download-box.txt)
+
+test -f download-box-aliyun.txt && ALIYUN_IMAGE=$(head -n 1 download-box-aliyun.txt)
+
+echo $IMAGE
+echo $ALIYUN_IMAGE
+
+IMAGE=$ALIYUN_IMAGE
+
+cd ${__PROJECT__}/var
+
+container_id=$(docker create $IMAGE) # returns container ID
+docker cp $container_id:/usr/share/nginx/html/extensions extensions
+docker cp $container_id:/usr/share/nginx/html/libraries libraries
+
+docker rm $container_id
+
+cd ${__PROJECT__}/
+
+awk 'BEGIN { cmd="cp -ri var/libraries/* pool/lib"  ; print "n" |cmd; }'
+awk 'BEGIN { cmd="cp -ri var/extensions/* pool/ext"; print "n" |cmd; }'

--- a/sapi/download-box/download-box-get-archive-from-server.sh
+++ b/sapi/download-box/download-box-get-archive-from-server.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+__PROJECT__=$(
+  cd ${__DIR__}/../../
+  pwd
+)
+cd ${__PROJECT__}
+
+test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
+
+cd ${__PROJECT__}/var
+
+DOMAIN='https://download-box.swoole.com/'
+QUERY_STRING="${DOMAIN}/all-archive.zip"
+URL="${domain}${DOMAIN}"
+
+wget -O all-archive.zip ${URL}
+
+unzip all-archive.zip
+
+cd ${__PROJECT__}/
+
+awk 'BEGIN { cmd="cp -ri var/libraries/* pool/lib"  ; print "n" |cmd; }'
+awk 'BEGIN { cmd="cp -ri var/extensions/* pool/ext"; print "n" |cmd; }'

--- a/sapi/download-box/download-box-get-archive-from-server.sh
+++ b/sapi/download-box/download-box-get-archive-from-server.sh
@@ -15,7 +15,7 @@ test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 cd ${__PROJECT__}/var
 
-DOMAIN='https://download-box.swoole.com/'
+DOMAIN='http://127.0.0.1:8015'
 QUERY_STRING="${DOMAIN}/all-archive.zip"
 URL="${domain}${DOMAIN}"
 

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+
+__PROJECT__=$(
+  cd ${__DIR__}/../../
+  pwd
+)
+
+cd ${__PROJECT__}
+
+export SWOOLE_CLI_SKIP_DOWNLOAD=1
+export SWOOLE_CLI_WITHOUT_DOCKER=1
+
+php prepare.php --with-build-type=release +ds +inotify +apcu
+
+cd ${__PROJECT__}
+
+test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
+
+sh sapi/download-dependencies-use-aria2.sh

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -16,7 +16,7 @@ cd ${__PROJECT__}
 export SWOOLE_CLI_SKIP_DOWNLOAD=1
 export SWOOLE_CLI_WITHOUT_DOCKER=1
 
-php prepare.php --with-build-type=release +ds +inotify +apcu
+php prepare.php  --with-build-type=release --skip-download=1 +ds +inotify +apcu
 
 cd ${__PROJECT__}
 

--- a/sapi/download-box/download-box-server-run.sh
+++ b/sapi/download-box/download-box-server-run.sh
@@ -12,8 +12,8 @@ __PROJECT__=$(
 cd ${__PROJECT__}
 
 IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
-IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230319T172427Z"
-ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230319T172427Z"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230320T064451Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230320T064451Z"
 
 cd ${__PROJECT__}/var
 

--- a/sapi/download-box/download-box-server-run.sh
+++ b/sapi/download-box/download-box-server-run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -exu
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+__PROJECT__=$(
+  cd ${__DIR__}/../../
+  pwd
+)
+cd ${__PROJECT__}
+
+IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230318T184831Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230318T184831Z"
+
+cd ${__PROJECT__}/var
+
+test -f download-box.txt && IMAGE=$(head -n 1 download-box.txt)
+
+test -f download-box-aliyun.txt && ALIYUN_IMAGE=$(head -n 1 download-box-aliyun.txt)
+
+echo $IMAGE
+echo $ALIYUN_IMAGE
+
+cd ${__PROJECT__}/
+{
+  docker stop download-box
+  docker rm download-box
+} || {
+  echo $?
+}
+docker run -d --rm --name download-box -p 8000:80 ${ALIYUN_IMAGE}

--- a/sapi/download-box/download-box-server-run.sh
+++ b/sapi/download-box/download-box-server-run.sh
@@ -12,8 +12,8 @@ __PROJECT__=$(
 cd ${__PROJECT__}
 
 IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
-IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230318T184831Z"
-ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230318T184831Z"
+IMAGE="docker.io/jingjingxyk/build-swoole-cli:download-box-nginx-alpine-20230319T172427Z"
+ALIYUN_IMAGE="registry.cn-beijing.aliyuncs.com/jingjingxyk-public/app:build-swoole-cli-download-box-nginx-alpine-20230319T172427Z"
 
 cd ${__PROJECT__}/var
 


### PR DESCRIPTION
# 创建依赖库镜像 和 使用依赖库的镜像

## 依赖库镜像创建

```bash 
    sh sapi/download-box/download-box-init.sh
    sh sapi/download-box/download-box-build.sh
```

## 依赖库镜像验证

```bash 
sh sapi/download-box/download-box-server-run.sh
```

## 依赖库镜像的分发方式

1. 通过容器仓库分发
1. 通过 web 分发

## 依赖库镜像的使用

### 方式一：

```bash
    sh sapi/download-box/download-box-get-archive-from-container.sh
```

### 方式二：

```bash
    sh sapi/download-box/download-box-get-archive-from-server.sh
```

### 方式三：
```bash
   php prepare.php   --enable-download-mirror  --with-download-mirror-url=http://127.0.0.1:8000 
```