### PR TITLE
添加使用自建镜像地址下载依赖库和扩展

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -1,5 +1,3 @@
-
-
 预处理参数
 =====
 
@@ -9,6 +7,7 @@
 * `--` 参数设置
 
 示例：
+
 ```shell
 ./prepare.php +mimalloc -mongodb --with-brotli=yes --conf-path="./conf.d" @linux
 ```
@@ -20,11 +19,14 @@
 ```
 
 也可以写作：
+
 ```shell
 SWOOLE_CLI_SKIP_DOWNLOAD=yes ./prepare.php
 ```
 
-> 参数设置优先于环境变量，当同时使用相同名称的参数设置和环境变量时，环境变量将被忽略，仅参数设置生效，例如：`SWOOLE_CLI_SKIP_DOWNLOAD=yes ./prepare.php --skip-download=no`，有效的值为：`--skip-download=no`，环境变量 `SWOOLE_CLI_SKIP_DOWNLOAD=yes` 无效
+>
+参数设置优先于环境变量，当同时使用相同名称的参数设置和环境变量时，环境变量将被忽略，仅参数设置生效，例如：`SWOOLE_CLI_SKIP_DOWNLOAD=yes ./prepare.php --skip-download=no`
+，有效的值为：`--skip-download=no`，环境变量 `SWOOLE_CLI_SKIP_DOWNLOAD=yes` 无效
 
 skip-download
 ----
@@ -38,6 +40,17 @@ skip-download
 
 # 构建依赖库之前，批量下载依赖库和扩展的脚本
 sh sapi/download-dependencies-use-aria2.sh
+
+```
+
+----
+使用镜像地址下载
+
+> 使用镜像地址下载下载前，需要准备镜像服务器 例如： `sh sapi/download-box/download-box-server-run.sh`
+
+```shell
+
+./prepare.php --without-docker --enable-download-mirror --with-download-mirror-url=http://127.0.0.1:8000
 
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -50,7 +50,7 @@ sh sapi/download-dependencies-use-aria2.sh
 
 ```shell
 
-./prepare.php --without-docker --enable-download-mirror --with-download-mirror-url=http://127.0.0.1:8000
+./prepare.php --without-docker --with-download-mirror-url=http://127.0.0.1:8000
 
 ```
 

--- a/sapi/Preprocessor.php
+++ b/sapi/Preprocessor.php
@@ -494,11 +494,7 @@ class Preprocessor
         if (empty($lib->file)) {
             $lib->file = basename($lib->url);
         }
-        if (
-            $this->getInputOption('enable-download-mirror')
-            &&
-            !empty($this->getInputOption('with-download-mirror-url'))
-        ) {
+        if (!empty($this->getInputOption('with-download-mirror-url'))) {
             $lib->url = $this->getInputOption('with-download-mirror-url') . '/libraries/' . $lib->file;
         }
         $skip_download = ($this->getInputOption('skip-download'));
@@ -531,15 +527,9 @@ class Preprocessor
             $ext->file = $ext->name . '-' . $ext->peclVersion . '.tgz';
             $ext->path = $this->extensionDir . '/' . $ext->file;
             $ext->url = "https://pecl.php.net/get/{$ext->file}";
-
-            if (
-                $this->getInputOption('enable-download-mirror')
-                &&
-                !empty($this->getInputOption('with-download-mirror-url'))
-            ) {
+            if (!empty($this->getInputOption('with-download-mirror-url'))) {
                 $ext->url = $this->getInputOption('with-download-mirror-url') . '/extensions/' . $ext->file;
             }
-
             if (!$this->getInputOption('skip-download')) {
                 if (!is_file($ext->path)) {
                     echo "[Extension] {$ext->file} not found, downloading: " . $ext->url . PHP_EOL;

--- a/sapi/Preprocessor.php
+++ b/sapi/Preprocessor.php
@@ -494,7 +494,13 @@ class Preprocessor
         if (empty($lib->file)) {
             $lib->file = basename($lib->url);
         }
-
+        if (
+            $this->getInputOption('enable-download-mirror')
+            &&
+            !empty($this->getInputOption('with-download-mirror-url'))
+        ) {
+            $lib->url = $this->getInputOption('with-download-mirror-url') . '/libraries/' . $lib->file;
+        }
         $skip_download = ($this->getInputOption('skip-download'));
         if (!$skip_download) {
             if (!is_file($this->libraryDir . '/' . $lib->file)) {
@@ -525,6 +531,14 @@ class Preprocessor
             $ext->file = $ext->name . '-' . $ext->peclVersion . '.tgz';
             $ext->path = $this->extensionDir . '/' . $ext->file;
             $ext->url = "https://pecl.php.net/get/{$ext->file}";
+
+            if (
+                $this->getInputOption('enable-download-mirror')
+                &&
+                !empty($this->getInputOption('with-download-mirror-url'))
+            ) {
+                $ext->url = $this->getInputOption('with-download-mirror-url') . '/extensions/' . $ext->file;
+            }
 
             if (!$this->getInputOption('skip-download')) {
                 if (!is_file($ext->path)) {

--- a/sapi/download-box/README.md
+++ b/sapi/download-box/README.md
@@ -9,11 +9,11 @@
 
 ## 依赖库镜像验证
 
-> 本地浏览器打开地址：   [`http://0.0.0.0:8000`](http://0.0.0.0:8000)  即可查看镜像服务器
-
 ```bash 
 sh sapi/download-box/download-box-server-run.sh
 ```
+
+> 本地浏览器打开地址：   [`http://0.0.0.0:8000`](http://0.0.0.0:8000)  即可查看镜像服务器
 
 ## 依赖库镜像的分发方式
 
@@ -22,14 +22,25 @@ sh sapi/download-box/download-box-server-run.sh
 
 ## 依赖库镜像的使用
 
-### 方式一：
+### 方式一（来自容器分发）：
 
 ```bash
     sh sapi/download-box/download-box-get-archive-from-container.sh
 ```
 
-### 方式二：
+### 方式二（来自web服务器）：
+
+> 原理： 下载：` http://127.0.0.1:8000/all-archive.zip`
+> 自动解压，并自动拷贝到 `pool/` 目录
 
 ```bash
     sh sapi/download-box/download-box-get-archive-from-server.sh
+```
+
+### 方式三（来自web服务器）：
+
+> 指定镜像地址 单个下载逐步
+
+```bash
+    ./prepare.php --without-docker --with-download-mirror=http://127.0.0.1:8000
 ```

--- a/sapi/download-box/download-box-get-archive-from-server.sh
+++ b/sapi/download-box/download-box-get-archive-from-server.sh
@@ -15,7 +15,7 @@ test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 cd ${__PROJECT__}/var
 
-DOMAIN='http://127.0.0.1:8015'
+DOMAIN='http://127.0.0.1:8000'
 QUERY_STRING="${DOMAIN}/all-archive.zip"
 URL="${domain}${DOMAIN}"
 

--- a/sapi/download-box/download-box-get-archive-from-server.sh
+++ b/sapi/download-box/download-box-get-archive-from-server.sh
@@ -16,8 +16,7 @@ test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 cd ${__PROJECT__}/var
 
 DOMAIN='http://127.0.0.1:8000'
-QUERY_STRING="${DOMAIN}/all-archive.zip"
-URL="${domain}${DOMAIN}"
+URL="${DOMAIN}/all-archive.zip"
 
 wget -O all-archive.zip ${URL}
 


### PR DESCRIPTION
自建依赖库和扩展镜像 ： https://github.com/swoole/swoole-cli/pull/81

测试例子：

```bash
# 启动依赖库镜像服务器
sh sapi/download-box/download-box-server-run.sh

## 执行下载
php prepare.php   --enable-download-mirror  --with-download-mirror-url=http://127.0.0.1:8000 

```

制作依赖库镜像服务： https://github.com/swoole/swoole-cli/pull/81 