### PR TITLE
修复下载 sourceforge.net 资源无效  和 改善批量下载

### DIFF
--- a/conf.d/gd.php
+++ b/conf.d/gd.php
@@ -45,6 +45,7 @@ EOF
             ->withHomePage('http://www.libpng.org/pub/png/libpng.html')
             ->withLicense('http://www.libpng.org/pub/png/src/libpng-LICENSE.txt', Library::LICENSE_SPEC)
             ->withUrl('https://nchc.dl.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.gz')
+            ->withMd5sum('6c7519f6c75939efa0ed3053197abd54')
             ->withPrefix($libpng_prefix)
             ->withConfigure(
                 <<<EOF
@@ -71,6 +72,7 @@ EOF
             ->withManual('https://giflib.sourceforge.net/intro.html')
             ->withLicense('https://giflib.sourceforge.net/intro.html', Library::LICENSE_SPEC)
             ->withUrl('https://nchc.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz')
+            ->withMd5sum('6f03aee4ebe54ac2cc1ab3e4b0a049e5')
             ->withPrefix($libgif_prefix)
             ->withMakeOptions('libgif.a')
             ->withMakeInstallCommand('')

--- a/conf.d/zlib.php
+++ b/conf.d/zlib.php
@@ -10,6 +10,7 @@ return function (Preprocessor $p) {
             ->withHomePage('https://zlib.net/')
             ->withLicense('https://zlib.net/zlib_license.html', Library::LICENSE_SPEC)
             ->withUrl('https://udomain.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz')
+            ->withMd5sum('1c9f62f0778697a09d36121ead88e08e')
             ->withPrefix(ZLIB_PREFIX)
             ->withConfigure('./configure --prefix=' . ZLIB_PREFIX . ' --static')
             ->withPkgName('zlib')

--- a/docs/options.md
+++ b/docs/options.md
@@ -12,7 +12,8 @@
 ./prepare.php --without-docker +mimalloc -mongodb --with-brotli=yes --conf-path="./conf.d" @linux
 ```
 
-参数设置也可以使用环境变量来代替，格式为 `SWOOLE_CLI_{$option}` ，需要将参数的中横线`-`替换为下划线`_`，例如：
+参数设置也可以使用环境变量来代替，格式为 `SWOOLE_CLI_{$option}`
+，需要将参数的中横线`-`替换为下划线`_`，例如：
 
 ```shell
 ./prepare.php --without-docker --skip-download=1
@@ -32,7 +33,7 @@ skip-download
 ----
 跳过下载依赖库
 
-> 会自动生成，待下载链接地址
+> 会自动生成，待下载链接地址 （依赖 aria2 )
 > 链接地址生成在 项目根目录下的 `var` 目录
 
 ```shell
@@ -44,9 +45,10 @@ sh sapi/scripts/download-dependencies-use-aria2.sh
 ```
 
 ----
-使用镜像地址下载
+[使用镜像地址下载](sapi/download-box/README.md)
 
-> 使用镜像地址下载下载前，需要准备镜像服务器 例如： `sh sapi/scripts/download-box/download-box-server-run.sh`
+> 使用镜像地址下载下载前，需要准备镜像服务器
+> 例如： `sh sapi/scripts/download-box/download-box-server-run.sh`
 
 ```shell
 # 演示例子
@@ -55,10 +57,6 @@ sh sapi/scripts/download-dependencies-use-aria2.sh
 # 可用镜像
 ./prepare.php --without-docker --with-download-mirror-url=https://swoole-cli.jingjingxyk.com/
 ```
-
-with-brotli
-----
-是否开启`brotli`压缩
 
 conf-path
 ----
@@ -83,15 +81,15 @@ with-dependency-graph
 > 依赖 graphviz
 
 ```shell
-brew install graphviz 
+brew install graphviz
 ```
 
 > 生成扩展依赖库 图 步骤
 
 ```shell
-php ./prepare.php --without-docker --with-dependency-graph=1 
+php ./prepare.php --without-docker --with-dependency-graph=1
 
  sh sapi/scripts/generate-dependency-graph.sh
- 
+
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -45,7 +45,7 @@ sh sapi/scripts/download-dependencies-use-aria2.sh
 
 ```
 
-[使用镜像地址下载](sapi/download-box/README.md)
+[使用镜像地址下载](/sapi/download-box/README.md)
 ----
 
 > 使用镜像地址下载下载前，需要准备镜像服务器

--- a/docs/options.md
+++ b/docs/options.md
@@ -93,9 +93,11 @@ apk add graphviz
 > 生成扩展依赖库 图 步骤
 
 ```shell
+# 生成扩展依赖图模板
 php ./prepare.php --without-docker --with-dependency-graph=1
 
- sh sapi/scripts/generate-dependency-graph.sh
+# 生成扩展依赖图
+sh sapi/scripts/generate-dependency-graph.sh
 
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -33,8 +33,9 @@ skip-download
 ----
 跳过下载依赖库
 
-> 会自动生成，待下载链接地址 （依赖 aria2 )
+> 会自动生成，待下载链接地址
 > 链接地址生成在 项目根目录下的 `var` 目录
+> 依赖 aria2
 
 ```shell
 ./prepare.php --skip-download=yes --without-docker
@@ -44,8 +45,8 @@ sh sapi/scripts/download-dependencies-use-aria2.sh
 
 ```
 
-----
 [使用镜像地址下载](sapi/download-box/README.md)
+----
 
 > 使用镜像地址下载下载前，需要准备镜像服务器
 > 例如： `sh sapi/scripts/download-box/download-box-server-run.sh`
@@ -81,7 +82,12 @@ with-dependency-graph
 > 依赖 graphviz
 
 ```shell
+# macos
 brew install graphviz
+# debian
+apt install -y graphviz
+# alpine
+apk add graphviz
 ```
 
 > 生成扩展依赖库 图 步骤

--- a/sapi/download-box/Dockerfile-dowload-box
+++ b/sapi/download-box/Dockerfile-dowload-box
@@ -5,3 +5,6 @@ ADD  ./default.conf /etc/nginx/conf.d/default.conf
 ADD  ./extensions  /usr/share/nginx/html/extensions
 ADD  ./libraries  /usr/share/nginx/html/libraries
 ADD  ./all-archive.zip  /usr/share/nginx/html/
+ADD  ./LICENSE /usr/share/nginx/html/
+ADD  ./credits.html /usr/share/nginx/html/
+ADD  ./ext-dependency-graph.pdf /usr/share/nginx/html/

--- a/sapi/download-box/README.md
+++ b/sapi/download-box/README.md
@@ -1,15 +1,15 @@
 # 创建依赖库镜像 和 使用依赖库的镜像
 
-## 创建依赖库镜像
+## 创建依赖库容器镜像
 
-```bash 
+```bash
     sh sapi/download-box/download-box-init.sh
     sh sapi/download-box/download-box-build.sh
 ```
 
-## 部署依赖库镜像
+## 部署依赖库容器镜像
 
-```bash 
+```bash
 sh sapi/download-box/download-box-server-run.sh
 ```
 
@@ -48,7 +48,7 @@ sh sapi/download-box/download-box-server-run.sh
 ```bash
     # 演示例子
     ./prepare.php --without-docker --with-download-mirror=http://127.0.0.1:8000
-    
-    # 真实可用的依赖库镜像 
+
+    # 真实可用的依赖库镜像
     ./prepare.php --without-docker --with-download-mirror=https://swoole-cli.jingjingxyk.com/
 ```

--- a/sapi/download-box/download-box-build.sh
+++ b/sapi/download-box/download-box-build.sh
@@ -15,6 +15,9 @@ test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 cp -f ${__DIR__}/Dockerfile-dowload-box ${__PROJECT__}/var
 cp -f ${__DIR__}/default.conf ${__PROJECT__}/var
+cp -f ${__DIR__}/bin/LICENSE ${__PROJECT__}/var
+cp -f ${__DIR__}/bin/credits.html ${__PROJECT__}/var
+cp -f ${__DIR__}/bin/ext-dependency-graph.pdf ${__PROJECT__}/var
 
 cd ${__PROJECT__}/var
 

--- a/sapi/download-box/download-box-get-archive-from-container.sh
+++ b/sapi/download-box/download-box-get-archive-from-container.sh
@@ -13,7 +13,6 @@ cd ${__PROJECT__}
 
 test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
-
 TAG='download-box-nginx-alpine-20230329T114730Z'
 
 IMAGE="docker.io/phpswoole/swoole-cli-builder:donload-box-v5.0.2"
@@ -40,6 +39,9 @@ docker cp $container_id:/usr/share/nginx/html/libraries libraries
 docker rm $container_id
 
 cd ${__PROJECT__}/
+
+mkdir -p pool/lib
+mkdir -p pool/ext
 
 awk 'BEGIN { cmd="cp -ri var/libraries/* pool/lib"  ; print "n" |cmd; }'
 awk 'BEGIN { cmd="cp -ri var/extensions/* pool/ext"; print "n" |cmd; }'

--- a/sapi/download-box/download-box-get-archive-from-server.sh
+++ b/sapi/download-box/download-box-get-archive-from-server.sh
@@ -11,6 +11,9 @@ __PROJECT__=$(
 )
 cd ${__PROJECT__}
 
+mkdir -p  pool/lib
+mkdir -p  pool/ext
+
 test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
 
 cd ${__PROJECT__}/var

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -20,10 +20,8 @@ export SWOOLE_CLI_SKIP_DOWNLOAD=1
 export SWOOLE_CLI_WITHOUT_DOCKER=1
 
 php prepare.php  --with-build-type=release  +ds +inotify +apcu +protobuf
-cd ${__PROJECT__}
 sh sapi/scripts/download-dependencies-use-aria2.sh
 
 # for macos
 php prepare.php  --with-build-type=release  +ds +apcu +protobuf +protobuf  @macos
-cd ${__PROJECT__}
 sh sapi/scripts/download-dependencies-use-aria2.sh

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -23,5 +23,5 @@ php prepare.php  --with-build-type=release  +ds +inotify +apcu +protobuf
 sh sapi/scripts/download-dependencies-use-aria2.sh
 
 # for macos
-php prepare.php  --with-build-type=release  +ds +apcu +protobuf +protobuf  @macos
+php prepare.php  --with-build-type=release  +ds +apcu +protobuf +protobuf  @macos --with-dependency-graph=1
 sh sapi/scripts/download-dependencies-use-aria2.sh

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -25,3 +25,6 @@ sh sapi/scripts/download-dependencies-use-aria2.sh
 # for macos
 php prepare.php  --with-build-type=release  +ds +apcu +protobuf +protobuf  @macos --with-dependency-graph=1
 sh sapi/scripts/download-dependencies-use-aria2.sh
+
+# 生成扩展依赖图
+sh sapi/scripts/generate-dependency-graph.sh

--- a/sapi/download-box/download-box-init.sh
+++ b/sapi/download-box/download-box-init.sh
@@ -13,13 +13,17 @@ __PROJECT__=$(
 
 cd ${__PROJECT__}
 
+test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
+
+
 export SWOOLE_CLI_SKIP_DOWNLOAD=1
 export SWOOLE_CLI_WITHOUT_DOCKER=1
 
-php prepare.php  --with-build-type=release --skip-download=1 +ds +inotify +apcu +protobuf
-
+php prepare.php  --with-build-type=release  +ds +inotify +apcu +protobuf
 cd ${__PROJECT__}
+sh sapi/scripts/download-dependencies-use-aria2.sh
 
-test -d ${__PROJECT__}/var || mkdir -p ${__PROJECT__}/var
-
+# for macos
+php prepare.php  --with-build-type=release  +ds +apcu +protobuf +protobuf  @macos
+cd ${__PROJECT__}
 sh sapi/scripts/download-dependencies-use-aria2.sh

--- a/sapi/scripts/download-dependencies-use-aria2.sh
+++ b/sapi/scripts/download-dependencies-use-aria2.sh
@@ -35,7 +35,7 @@ EOF
 user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
 
 
-test -f download_library_urls.txt  && aria2c -c -j 10 -s 10 -x 8 -k 10M --allow-overwrite=true --max-tries=30  --retry-wait=15 --user-agent=$user_agent \
+test -f download_library_urls.txt  && aria2c -c -j 10 -s 10 -x 8 -k 10M --allow-overwrite=true --max-tries=30  --retry-wait=15  \
  -d libraries --input-file=download_library_urls.txt
 
 

--- a/sapi/src/Preprocessor.php
+++ b/sapi/src/Preprocessor.php
@@ -291,9 +291,8 @@ class Preprocessor
     protected function downloadFile(string $url, string $file, string $md5sum)
     {
         $retry_number = DOWNLOAD_FILE_RETRY_NUMBE;
-        $user_agent = DOWNLOAD_FILE_USER_AGENT;
         $wait_retry = DOWNLOAD_FILE_WAIT_RETRY;
-        echo $cmd = "wget   {$url}  -O {$file}  -t {$retry_number} --wait={$wait_retry} -T 15 --user-agent='{$user_agent}'";
+        echo $cmd = "wget   {$url}  -O {$file}  -t {$retry_number} --wait={$wait_retry} -T 15 ";
         echo PHP_EOL;
         echo `$cmd`;
         echo PHP_EOL;


### PR DESCRIPTION
1. 因 sourceforge.net  站点 依据 User-Agent  返回的重定向地址。导致返回的数据不符合预期
2. 改善批量下载
3. 完善构建镜像依赖库容器镜像