### PR TITLE
使用已经构建好的库，跳过库编译、安装步骤

### DIFF
--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -49,7 +49,7 @@ jobs:
             # composer update --no-dev  --optimize-autoloader
             composer update   --optimize-autoloader
 
-            php prepare.php  --with-swoole-pgsql=1  +inotify +apcu +ds +xlswriter +ssh2 --with-install-library-cached=1
+            php prepare.php +inotify +apcu +ds +xlswriter +ssh2 --with-swoole-pgsql=1 --with-install-library-cached=1
 
             chmod a+x make.sh
             head -n 20 make.sh

--- a/.github/workflows/linux-aarch64.yml
+++ b/.github/workflows/linux-aarch64.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   linux-aarch64:
-    if: 0
+    if: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,10 +49,20 @@ jobs:
             # composer update --no-dev  --optimize-autoloader
             composer update   --optimize-autoloader
 
-            php prepare.php  --with-swoole-pgsql=1  +inotify +apcu +ds +xlswriter +ssh2
+            php prepare.php  --with-swoole-pgsql=1  +inotify +apcu +ds +xlswriter +ssh2 --with-install-library-cached=1
 
             chmod a+x make.sh
             head -n 20 make.sh
+
+      - name: Build all-library
+        uses: addnab/docker-run-action@v3
+        with:
+          image: docker.io/jingjingxyk/build-swoole-cli:all-dependencies-alpine-3.17-php8-v1.0.0-aarch64-20230614T152332Z
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: |
+            bash sapi/quickstart/mark-install-library-cached.sh
+            bash ./make.sh all-library
+
       - name: Build
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/linux-x86_64-all.yml
+++ b/.github/workflows/linux-x86_64-all.yml
@@ -56,7 +56,7 @@ jobs:
             # composer update --no-dev  --optimize-autoloader
             composer update   --optimize-autoloader
 
-            php prepare.php  --with-swoole-pgsql=1  +inotify +apcu +ds +xlswriter +ssh2
+            php prepare.php +inotify +apcu +ds +xlswriter +ssh2 --with-swoole-pgsql=1
 
             chmod a+x make.sh
 

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -62,6 +62,15 @@ jobs:
             chmod a+x make.sh
             head -n 20 make.sh
 
+      - name: Build all-library
+        uses: addnab/docker-run-action@v3
+        with:
+          image: docker.io/jingjingxyk/build-swoole-cli:all-dependencies-alpine-3.17-php8-v1.0.0-x86_64-20230614T150918Z
+          options: -v ${{ github.workspace }}:/work -w /work
+          run: |
+            bash sapi/quickstart/mark-install-library-cached.sh
+            bash ./make.sh all-library
+
       - name: Build
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/linux-x86_64.yml
+++ b/.github/workflows/linux-x86_64.yml
@@ -57,7 +57,7 @@ jobs:
             # composer update --no-dev  --optimize-autoloader
             composer update   --optimize-autoloader
 
-            php prepare.php   --with-swoole-pgsql=1 +inotify +apcu +ds +xlswriter +ssh2
+            php prepare.php  +inotify +apcu +ds +xlswriter +ssh2 --with-swoole-pgsql=1 --with-install-library-cached=1
 
             chmod a+x make.sh
             head -n 20 make.sh

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -76,7 +76,7 @@ jobs:
           # composer update --no-dev  --optimize-autoloader
           composer update  --optimize-autoloader
 
-          php prepare.php --without-docker=1  --with-build-type=release --with-swoole-pgsql=1  +ds +apcu  +xlswriter +ssh2
+          php prepare.php --without-docker=1  --with-build-type=release  +ds +apcu  +xlswriter +ssh2 --with-swoole-pgsql=1 --with-install-library-cached=1
 
       - name: Cache all-library
         uses: actions/cache@v3

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -84,11 +84,6 @@ jobs:
         with:
           path: /usr/local/swoole-cli
           key: ${{ runner.os }}-build-all-library
-      - name: Build all-library
-        if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}
-        run: |
-          export PATH=${GITHUB_WORKSPACE}/bin/runtime:$PATH
-          bash ./make.sh all-library
 
       - name: Build all-library
         if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -86,7 +86,7 @@ jobs:
           key: ${{ runner.os }}-build-all-library
 
       - name: Build all-library
-        if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}
+        # if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}
         run: |
           export PATH=${GITHUB_WORKSPACE}/bin/runtime:$PATH
           bash sapi/quickstart/mark-install-library-cached.sh

--- a/.github/workflows/macos-x86_64.yml
+++ b/.github/workflows/macos-x86_64.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   macos-x86_64:
-    if: 0
+    if: 1
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -88,6 +88,13 @@ jobs:
         if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}
         run: |
           export PATH=${GITHUB_WORKSPACE}/bin/runtime:$PATH
+          bash ./make.sh all-library
+
+      - name: Build all-library
+        if: ${{ steps.all-library-cache.outputs.cache-hit != 'true' }}
+        run: |
+          export PATH=${GITHUB_WORKSPACE}/bin/runtime:$PATH
+          bash sapi/quickstart/mark-install-library-cached.sh
           bash ./make.sh all-library
 
       - name: Build

--- a/docs/options.md
+++ b/docs/options.md
@@ -136,9 +136,9 @@ php ./prepare.php --with-parallel-jobs=8
 
 with-install-library-cached
 ----
-使用库缓存，实现复用已构建、安装的库
-例子：将已经构建好的openssl库，打包进入容器，使用容器环境构建时，即可跳过 openssl
-库的构建 和 安装
+使用库缓存，复用已构建、安装的库
+例子：将构建好的openssl库，打包进入容器，使用容器环境构建时，即可跳过 openssl
+构建、安装过程
 
 ```shell
 php ./prepare.php --with-install-library-cached=1

--- a/docs/options.md
+++ b/docs/options.md
@@ -133,3 +133,13 @@ with-parallel-jobs
 ```shell
 php ./prepare.php --with-parallel-jobs=8
 ```
+
+with-install-library-cached
+----
+使用库缓存，实现复用已构建、安装的库
+例子：将已经构建好的openssl库，打包进入容器，使用容器环境构建时，即可跳过 openssl
+库的构建 和 安装
+
+```shell
+php ./prepare.php --with-install-library-cached=1
+```

--- a/prepare.php
+++ b/prepare.php
@@ -27,6 +27,10 @@ if ($p->getInputOption('with-parallel-jobs')) {
     $p->setMaxJob(intval($p->getInputOption('with-parallel-jobs')));
 }
 
+if ($p->getInputOption('with-install-library-cached')) {
+    $p->setInstallLibraryCached(true);
+}
+
 if ($p->getOsType() == 'macos') {
     $p->setExtraLdflags('-undefined dynamic_lookup');
     $p->setLinker('ld');

--- a/sapi/quickstart/mark-install-library-cached.sh
+++ b/sapi/quickstart/mark-install-library-cached.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -x
+__DIR__=$(
+  cd "$(dirname "$0")"
+  pwd
+)
+
+cd ${__DIR__}
+
+LIBRARIES=$(
+cat <<-EOF
+openssl
+cares
+libiconv
+libxml2
+bzip2
+zlib
+brotli
+liblz4
+liblzma
+libzstd
+nghttp2
+nghttp3
+ngtcp2
+libssh2
+curl
+oniguruma
+libzip
+sqlite3
+icu
+libxslt
+gmp
+libsodium
+ncurses
+readline
+libjpeg
+libpng
+freetype
+libgif
+libwebp
+pgsql
+libyaml
+imagemagick
+EOF
+)
+echo $LIBRARIES
+for i in $LIBRARIES
+do
+  echo $i
+  if [ -d /usr/local/swoole-cli/$i ];then
+    touch /usr/local/swoole-cli/$i/.completed
+  fi
+done
+
+exit 0 ;
+LIBRARIES=$(echo $LIBRARIES | sed 's/ /,/g')
+

--- a/sapi/src/Library.php
+++ b/sapi/src/Library.php
@@ -5,7 +5,9 @@ namespace SwooleCli;
 class Library extends Project
 {
     public array $mirrorUrls = [];
+
     public string $configure = '';
+
     public string $ldflags = '';
 
     public string $buildScript = '';
@@ -17,9 +19,12 @@ class Library extends Project
     public string $afterInstallScript = '';
     public string $pkgConfig = '';
     public array $pkgNames = [];
+
     public string $prefix = '/usr';
 
     public string $binPath = '';
+
+    public bool $enableBuildLibraryCached = true;
 
     public function withMirrorUrl(string $url): static
     {
@@ -115,6 +120,12 @@ class Library extends Project
     public function withBinPath(string $path): static
     {
         $this->binPath = $path;
+        return $this;
+    }
+
+    public function withBuildLibraryCached(bool $enableBuildLibraryCached): static
+    {
+        $this->enableBuildLibraryCached = $enableBuildLibraryCached;
         return $this;
     }
 }

--- a/sapi/src/Preprocessor.php
+++ b/sapi/src/Preprocessor.php
@@ -22,6 +22,7 @@ class Preprocessor
 
     protected string $cCompiler = 'clang';
     protected string $cppCompiler = 'clang++';
+
     protected string $lld = 'ld.lld';
 
     protected array $downloadExtensionList = [];
@@ -125,6 +126,8 @@ class Preprocessor
     protected array $endCallbacks = [];
     protected array $extCallbacks = [];
     protected string $configureVarables;
+
+    protected bool $installLibraryCached = false;
 
     protected function __construct()
     {
@@ -295,6 +298,10 @@ class Preprocessor
         $this->extraOptions = $options;
     }
 
+    public function setInstallLibraryCached(bool $installLibraryCached): void
+    {
+        $this->installLibraryCached = $installLibraryCached;
+    }
     /**
      * make -j {$n}
      * @param string $n

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -44,7 +44,7 @@ make_<?=$item->name?>() {
     fi
     <?php if ($this->installLibraryCached) :?>
     if [ -f <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/.completed ] ;then
-        echo "[<?=$item->name?>]  compiled, skip.."
+        echo "[<?=$item->name?>]  library cached , skip.."
         return 0
     fi
     <?php endif;?>

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -42,7 +42,12 @@ make_<?=$item->name?>() {
             exit  $result_code
         fi
     fi
-
+    <?php if ($this->installLibraryCached) :?>
+    if [ -f <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/.completed ] ;then
+        echo "[<?=$item->name?>]  compiled, skip.."
+        return 0
+    fi
+    <?php endif;?>
     if [ -f <?=$this->getBuildDir()?>/<?=$item->name?>/.completed ]; then
         echo "[<?=$item->name?>] compiled, skip.."
         cd <?= $this->workDir ?>/
@@ -97,7 +102,14 @@ __EOF__
     [[ $result_code -ne 0 ]] &&  echo "[<?=$item->name?>] [ after make  install script FAILURE]" && exit  $result_code;
     <?php endif; ?>
 
+    <?php if ($item->enableBuildLibraryCached) : ?>
     touch <?=$this->getBuildDir()?>/<?=$item->name?>/.completed
+        <?php if ($this->installLibraryCached) :?>
+    if [ -d <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/] ;then
+         touch <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/.completed
+    fi
+        <?php endif;?>
+    <?php endif; ?>
 
     cd <?= $this->workDir . PHP_EOL ?>
     return 0

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -105,7 +105,7 @@ __EOF__
     <?php if ($item->enableBuildLibraryCached) : ?>
     touch <?=$this->getBuildDir()?>/<?=$item->name?>/.completed
         <?php if ($this->installLibraryCached) :?>
-    if [ -d <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/] ;then
+    if [ -d <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/ ] ;then
          touch <?= $this->getGlobalPrefix() . '/'.  $item->name ?>/.completed
     fi
         <?php endif;?>


### PR DESCRIPTION
添加 --with-install-library-cached=1 参数，使用已经构建好的库。

目的： 跳过库 构建、安装步骤

用途： bash make.sh all-library   （跳过已经安装的库）


用途案例： https://github.com/jingjingxyk/swoole-cli/pull/75  （gd 启用libavif库支持）


