### PR TITLE
解决brotli 链接不上的bug

### DIFF
--- a/sapi/src/builder/library/freetype.php
+++ b/sapi/src/builder/library/freetype.php
@@ -19,14 +19,16 @@ return function (Preprocessor $p) {
             ->withConfigure(
                 <<<EOF
             ./configure --help
+            PACKAGES='zlib libpng  libbrotlicommon  libbrotlienc libbrotlidec '
             BZIP2_CFLAGS="-I{$bzip2_prefix}/include"  \
             BZIP2_LIBS="-L{$bzip2_prefix}/lib -lbz2"  \
-            CPPFLAGS="$(pkg-config --cflags-only-I --static zlib libpng  libbrotlicommon  libbrotlidec  libbrotlienc)" \
-            LDFLAGS="$(pkg-config  --libs-only-L   --static zlib libpng  libbrotlicommon  libbrotlidec  libbrotlienc)" \
-            LIBS="$(pkg-config     --libs-only-l   --static zlib libpng  libbrotlicommon  libbrotlidec  libbrotlienc)" \
-            ./configure --prefix={$freetype_prefix} \
-            --enable-static \
-            --disable-shared \
+            CPPFLAGS="$(pkg-config --cflags-only-I --static \$PACKAGES)" \
+            LDFLAGS="$(pkg-config  --libs-only-L   --static \$PACKAGES)" \
+            LIBS="$(pkg-config     --libs-only-l   --static \$PACKAGES)" \
+            ./configure \
+            --prefix={$freetype_prefix} \
+            --enable-shared=no \
+            --enable-static=yes \
             --with-zlib=yes \
             --with-bzip2=yes \
             --with-png=yes \


### PR DESCRIPTION
折腾了好久 gd 启用支持libavif ，链接阶段总是找不到brotli 库。排除法，最后发现是freetype 编译的问题

这是错误的配置： https://github.com/swoole/swoole-cli/blob/b9253c69243250d33e2ad3e79a460b3d3c651016/sapi/src/builder/library/freetype.php#L28
```text
--enable-static \
--disable-shared \

```


正确的配置如下：
```text

--enable-shared=no \
--enable-static=yes \
```