### PR TITLE
改进 构建缓存使用；新增构建阶段使用代理；swoole 子模块移动到sapi/swoole

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sapi/swoole"]
+	path = sapi/swoole
+	url = https://github.com/swoole/swoole-src.git

--- a/prepare.php
+++ b/prepare.php
@@ -5,13 +5,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 use SwooleCli\Preprocessor;
 
-const BUILD_PHP_VERSION = '8.1.12';
-
-$homeDir = getenv('HOME');
-$p = Preprocessor::getInstance();
-$p->parseArguments($argc, $argv);
-
-# clean
+# clean old make.sh
 if (file_exists(__DIR__ . '/make.sh')) {
     unlink(__DIR__ . '/make.sh');
 }
@@ -21,6 +15,13 @@ if (file_exists(__DIR__ . '/make-install-deps.sh')) {
 if (file_exists(__DIR__ . '/make-download-box.sh')) {
     unlink(__DIR__ . '/make-download-box.sh');
 }
+
+const BUILD_PHP_VERSION = '8.1.12';
+
+$homeDir = getenv('HOME');
+$p = Preprocessor::getInstance();
+$p->parseArguments($argc, $argv);
+
 
 // Sync code from php-src
 $p->setPhpSrcDir($homeDir . '/.phpbrew/build/php-' . BUILD_PHP_VERSION);

--- a/sapi/src/Library.php
+++ b/sapi/src/Library.php
@@ -34,6 +34,8 @@ class Library extends Project
 
     public string $preInstallCommand = '';
 
+    public bool $enableBuildLibraryHttpProxy = false;
+
     public function withMirrorUrl(string $url): static
     {
         $this->mirrorUrls[] = $url;
@@ -159,6 +161,12 @@ class Library extends Project
     public function withPreInstallCommand(string $preInstallCommand): static
     {
         $this->preInstallCommand = $preInstallCommand;
+        return $this;
+    }
+
+    public function withBuildLibraryHttpProxy(bool $enableBuildLibraryHttpProxy = true): static
+    {
+        $this->enableBuildLibraryHttpProxy = $enableBuildLibraryHttpProxy;
         return $this;
     }
 }

--- a/sapi/src/builder/extension/swoole_git.php
+++ b/sapi/src/builder/extension/swoole_git.php
@@ -1,0 +1,39 @@
+<?php
+
+use SwooleCli\Library;
+use SwooleCli\Preprocessor;
+use SwooleCli\Extension;
+
+return function (Preprocessor $p) {
+    $depends = ['curl', 'openssl', 'cares', 'zlib', 'brotli', 'nghttp2'];
+
+    $options = '--enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares ';
+    $options .= ' --with-brotli-dir=' . BROTLI_PREFIX;
+    $options .= ' --with-nghttp2-dir=' . NGHTTP2_PREFIX;
+
+    if ($p->getInputOption('with-swoole-pgsql')) {
+        $options .= ' --enable-swoole-pgsql';
+        $depends[] = 'pgsql';
+    }
+
+    $rootDir = $p->getRootDir();
+    $ext = (new Extension('swoole_git'))
+        ->withAliasName('swoole')
+        ->withOptions($options)
+        ->withLicense('https://github.com/swoole/swoole-src/blob/master/LICENSE', Extension::LICENSE_APACHE2)
+        ->withHomePage('https://github.com/swoole/swoole-src')
+        ->withManual('https://wiki.swoole.com/#/')
+        ->withFile('swoole-git-submodule.tar.gz')
+        ->withAutoUpdateFile(true)
+        # 自动 拷贝子模块 swoole 的源代码到 pool/ext/ 目录
+        # swoole 版本由子模块控制
+        ->withDownloadScript(
+            'swoole',
+            <<<EOF
+            cd {$rootDir}/sapi
+EOF
+        )
+        ->withDependentExtensions('curl', 'openssl', 'sockets', 'mysqlnd', 'pdo');
+    call_user_func_array([$ext, 'withDependentLibraries'], $depends);
+    $p->addExtension($ext);
+};

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -154,6 +154,9 @@ clean_<?=$item->name?>() {
 clean_<?=$item->name?>_cached() {
     echo "clean <?=$item->name?> [cached]"
     rm <?=$this->getBuildDir()?>/<?=$item->name?>/.completed
+    if [ -f <?=$this->getGlobalPrefix()?>/<?=$item->name?>/.completed ] ;then
+        rm -f <?=$this->getGlobalPrefix()?>/<?=$item->name?>/.completed
+    fi
 }
 
     <?php echo str_repeat(PHP_EOL, 1);?>
@@ -249,6 +252,7 @@ make_clean() {
 }
 
 show_lib_pkgs() {
+    set +x
 <?php foreach ($this->libraryList as $item) : ?>
     <?php if (!empty($item->pkgNames)) : ?>
         echo -e "[<?= $item->name ?>] pkg-config : \n<?= implode(' ', $item->pkgNames) ?>" ;
@@ -261,6 +265,7 @@ show_lib_pkgs() {
 }
 
 show_lib_dependent_pkgs() {
+    set +x
     declare -A array_name
 <?php foreach ($this->libraryList as $item) :?>
     <?php


### PR DESCRIPTION
1、改进 构建缓存使用；
2、新增构建阶段使用代理；
3、swoole 子模块移动到sapi/swoole 

验证命令：
使用已经构建好的依赖库
```shell

bash sapi/quickstart/linux/run-alpine-container-full.sh

bash sapi/quickstart/linux/connection-swoole-cli-alpine.sh

bash sapi/quickstart/mark-install-library-cached.sh

php prepare.php -swoole +swoole_git --with-install-library-cached=1  --with-http-proxy=http://192.168.3.26:8015
```