### PR TITLE
update zlib  download url  解决 zlib 下载地址不可用

### DIFF
--- a/sapi/src/builder/library/freetype.php
+++ b/sapi/src/builder/library/freetype.php
@@ -14,7 +14,7 @@ return function (Preprocessor $p) {
                 'https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/docs/GPLv2.TXT',
                 Library::LICENSE_GPL
             )
-            ->withUrl('https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz')
+            ->withUrl('https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/freetype-2.10.4.tar.gz')
             ->withPrefix($freetype_prefix)
             ->withConfigure(
                 <<<EOF

--- a/sapi/src/builder/library/zlib.php
+++ b/sapi/src/builder/library/zlib.php
@@ -8,7 +8,7 @@ return function (Preprocessor $p) {
         (new Library('zlib'))
             ->withHomePage('https://zlib.net/')
             ->withLicense('https://zlib.net/zlib_license.html', Library::LICENSE_SPEC)
-            ->withUrl('https://udomain.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz')
+            ->withUrl('https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz')
             ->withMd5sum('1c9f62f0778697a09d36121ead88e08e')
             ->withPrefix(ZLIB_PREFIX)
             ->withConfigure('./configure --prefix=' . ZLIB_PREFIX . ' --static')


### PR DESCRIPTION
 zlib 下载地址不可用 详情： https://github.com/swoole/swoole-cli/actions/runs/6862248629/job/18659569681


![image](https://github.com/swoole/swoole-cli/assets/6836228/f6871eef-2bc1-47f2-8368-69d7a07c449d)
