### PR TITLE
准备 v5.1.4.0 版本

### DIFF
--- a/sapi/scripts/cygwin/cygwin-config.sh
+++ b/sapi/scripts/cygwin/cygwin-config.sh
@@ -11,51 +11,48 @@ __PROJECT__=$(
 )
 cd ${__PROJECT__}
 
-
-
 ./buildconf --force
 test -f Makefile && make clean
 ./configure --prefix=/usr --disable-all \
-    --enable-zts \
-    --disable-fiber-asm \
-    --without-pcre-jit \
-    --with-openssl --enable-openssl \
-    --with-curl \
-    --with-iconv \
-    --enable-intl \
-    --with-bz2 \
-    --enable-bcmath \
-    --enable-filter \
-    --enable-session \
-    --enable-tokenizer \
-    --enable-mbstring \
-    --enable-ctype \
-    --with-zlib \
-    --with-zip \
-    --enable-posix \
-    --enable-sockets \
-    --enable-pdo \
-    --with-sqlite3 \
-    --enable-phar \
-    --enable-pcntl \
-    --enable-mysqlnd \
-    --with-mysqli \
-    --enable-fileinfo \
-    --with-pdo_mysql \
-    --enable-soap \
-    --with-xsl \
-    --with-gmp \
-    --enable-exif \
-    --with-sodium \
-    --enable-xml --enable-simplexml --enable-xmlreader --enable-xmlwriter --enable-dom --with-libxml \
-    --enable-gd --with-jpeg  --with-freetype \
-    --enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares \
-    --enable-swoole-pgsql \
-    --enable-swoole-sqlite \
-    --enable-swoole-thread \
-    --enable-redis \
-    --with-imagick \
-    --with-yaml \
-    --with-readline \
-    --enable-opcache \
-    --disable-opcache-jit
+  --enable-opcache \
+  --disable-fiber-asm \
+  --without-pcre-jit \
+  --with-openssl --enable-openssl \
+  --with-curl \
+  --with-iconv \
+  --enable-intl \
+  --with-bz2 \
+  --enable-bcmath \
+  --enable-filter \
+  --enable-session \
+  --enable-tokenizer \
+  --enable-mbstring \
+  --enable-ctype \
+  --with-zlib \
+  --with-zip \
+  --enable-posix \
+  --enable-sockets \
+  --enable-pdo \
+  --with-sqlite3 \
+  --enable-phar \
+  --enable-pcntl \
+  --enable-mysqlnd \
+  --with-mysqli \
+  --enable-fileinfo \
+  --with-pdo_mysql \
+  --enable-soap \
+  --with-xsl \
+  --with-gmp \
+  --enable-exif \
+  --with-sodium \
+  --enable-xml --enable-simplexml --enable-xmlreader --enable-xmlwriter --enable-dom --with-libxml \
+  --enable-gd --with-jpeg --with-freetype \
+  --enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares \
+  --enable-swoole-pgsql \
+  --enable-swoole-sqlite \
+  --enable-redis \
+  --with-imagick \
+  --with-yaml \
+  --with-readline
+
+#    --with-pdo-sqlite \

--- a/sapi/scripts/cygwin/cygwin-config.sh
+++ b/sapi/scripts/cygwin/cygwin-config.sh
@@ -14,45 +14,45 @@ cd ${__PROJECT__}
 ./buildconf --force
 test -f Makefile && make clean
 ./configure --prefix=/usr --disable-all \
-  --enable-opcache \
-  --disable-fiber-asm \
-  --without-pcre-jit \
-  --with-openssl --enable-openssl \
-  --with-curl \
-  --with-iconv \
-  --enable-intl \
-  --with-bz2 \
-  --enable-bcmath \
-  --enable-filter \
-  --enable-session \
-  --enable-tokenizer \
-  --enable-mbstring \
-  --enable-ctype \
-  --with-zlib \
-  --with-zip \
-  --enable-posix \
-  --enable-sockets \
-  --enable-pdo \
-  --with-sqlite3 \
-  --enable-phar \
-  --enable-pcntl \
-  --enable-mysqlnd \
-  --with-mysqli \
-  --enable-fileinfo \
-  --with-pdo_mysql \
-  --enable-soap \
-  --with-xsl \
-  --with-gmp \
-  --enable-exif \
-  --with-sodium \
-  --enable-xml --enable-simplexml --enable-xmlreader --enable-xmlwriter --enable-dom --with-libxml \
-  --enable-gd --with-jpeg --with-freetype \
-  --enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares \
-  --enable-swoole-pgsql \
-  --enable-swoole-sqlite \
-  --enable-redis \
-  --with-imagick \
-  --with-yaml \
-  --with-readline
+    --enable-opcache \
+    --disable-fiber-asm \
+    --without-pcre-jit \
+    --with-openssl --enable-openssl \
+    --with-curl \
+    --with-iconv \
+    --enable-intl \
+    --with-bz2 \
+    --enable-bcmath \
+    --enable-filter \
+    --enable-session \
+    --enable-tokenizer \
+    --enable-mbstring \
+    --enable-ctype \
+    --with-zlib \
+    --with-zip \
+    --enable-posix \
+    --enable-sockets \
+    --enable-pdo \
+    --with-sqlite3 \
+    --enable-phar \
+    --enable-pcntl \
+    --enable-mysqlnd \
+    --with-mysqli \
+    --enable-fileinfo \
+    --with-pdo_mysql \
+    --enable-soap \
+    --with-xsl \
+    --with-gmp \
+    --enable-exif \
+    --with-sodium \
+    --enable-xml --enable-simplexml --enable-xmlreader --enable-xmlwriter --enable-dom --with-libxml \
+    --enable-gd --with-jpeg --with-freetype \
+    --enable-swoole --enable-sockets --enable-mysqlnd --enable-swoole-curl --enable-cares \
+    --enable-swoole-pgsql \
+    --enable-swoole-sqlite \
+    --enable-redis \
+    --with-imagick \
+    --with-yaml \
+    --with-readline
 
-#    --with-pdo-sqlite \
+    #    --with-pdo-sqlite \

--- a/sapi/src/builder/extension/opcache.php
+++ b/sapi/src/builder/extension/opcache.php
@@ -7,7 +7,6 @@ return function (Preprocessor $p) {
     $p->addExtension(
         (new Extension('opcache'))
             ->withHomePage('https://www.php.net/opcache')
-            # zts 模式下， 静态编译 opcache-jit 报错 ，更多信息： https://github.com/php/php-src/issues/15074
-            ->withOptions('--enable-opcache --disable-opcache-jit')
+            ->withOptions('--enable-opcache')
     );
 };

--- a/sapi/src/builder/extension/swoole.php
+++ b/sapi/src/builder/extension/swoole.php
@@ -18,14 +18,6 @@ return function (Preprocessor $p) {
     $options[] = '--enable-swoole-pgsql';
     $options[] = '--enable-swoole-sqlite';
     $options[] = '--with-swoole-odbc=unixODBC,' . UNIX_ODBC_PREFIX;
-    $options[] = '--enable-swoole-thread';
-
-    if ($p->isLinux() && $p->getInputOption('with-iouring')) {
-        $options[] = '--enable-iouring';
-        $dependentLibraries[] = 'liburing';
-        $p->withExportVariable('URING_CFLAGS', '$(pkg-config  --cflags --static  liburing)');
-        $p->withExportVariable('URING_LIBS', '$(pkg-config    --libs   --static  liburing)');
-    }
 
     $p->addExtension((new Extension('swoole'))
         ->withHomePage('https://github.com/swoole/swoole-src')

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -24,7 +24,6 @@ export PATH=<?= implode(':', $this->binPaths) . PHP_EOL ?>
 OPTIONS="--disable-all \
 --enable-shared=no \
 --enable-static=yes \
---enable-zts \
 <?php foreach ($this->extensionList as $item) : ?>
     <?=$item->options?> \
 <?php endforeach; ?>


### PR DESCRIPTION

发版信息：

| item           | value      |
|----------------|------------|
| branch         | v5.1.x     |
| tag            | v5.1.4.0   |
| swoole version | v5.1.4     |
| php  version   | 8.1.29     |
| release date   | 2024-08-27 |

## 变更：

    1.  修复 libiconv 下载地址错误
    2.  swoole 版本由 v5.1.3 升级为 v5.1.4
    3.  新增下载 swoole-cli 脚本
    4.  PHP 版本由 8.1.27 升级为 8.1.29
    5.  优化 pool 目录打包为 all-deps.zip 

## 立即下载使用 swoole-cli

```shell

curl -fSL https://github.com/swoole/swoole-cli/blob/main/setup-swoole-cli-runtime.sh?raw=true | bash

# 来自 https://www.swoole.com/download
curl -fSL https://github.com/swoole/swoole-cli/blob/main/setup-swoole-cli-runtime.sh?raw=true | bash -s -- --mirror china

```

## 备注： macos环境下 首次运行提示无权限 ，解决方法

note : macos clearing the com.apple.quarantine extended attribute

```
xattr ./bin/runtime/swoole-cli

sudo xattr -rd com.apple.quarantine  ./bin/runtime/swoole-cli

```
