### PR TITLE
Feature fix readline not work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,4 +324,4 @@ Makefile.backup
 ldflags.log
 cppflags.log
 libs.log
-
+/*.patch

--- a/.gitignore
+++ b/.gitignore
@@ -324,4 +324,4 @@ Makefile.backup
 ldflags.log
 cppflags.log
 libs.log
-/*.patch
+!sapi/patches

--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -744,24 +744,9 @@ typedef cli_shell_callbacks_t *(__cdecl *get_cli_shell_callbacks)(void);
 	} while(0)
 
 #else
-/*
-#ifdef COMPILE_DL_READLINE
-This dlsym() is always used as even the CGI SAPI is linked against "CLI"-only
-extensions. If that is being changed dlsym() should only be used when building
-this extension sharedto offer compatibility.
-*/
-#define GET_SHELL_CB(cb) \
-	do { \
-		(cb) = NULL; \
-		cli_shell_callbacks_t *(*get_callbacks)(void); \
-		get_callbacks = dlsym(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
-		if (get_callbacks) { \
-			(cb) = get_callbacks(); \
-		} \
-	} while(0)
-/*#else
+
 #define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()
-#endif*/
+
 #endif
 
 PHP_MINIT_FUNCTION(cli_readline)

--- a/sapi/patches/0001-fix-readline-not-work.patch
+++ b/sapi/patches/0001-fix-readline-not-work.patch
@@ -1,0 +1,43 @@
+From 2a15bd4c55d8d2f46d2e17d4f7e642a2387d6e01 Mon Sep 17 00:00:00 2001
+From: jingjingxyk <zonghengbaihe521@qq.com>
+Date: Sun, 6 Oct 2024 18:59:27 +0800
+Subject: [PATCH] fix readline not work
+
+---
+ ext/readline/readline_cli.c | 19 ++-----------------
+ 1 file changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/ext/readline/readline_cli.c b/ext/readline/readline_cli.c
+index 8bf5d23df..0adecf42a 100644
+--- a/ext/readline/readline_cli.c
++++ b/ext/readline/readline_cli.c
+@@ -744,24 +744,9 @@ typedef cli_shell_callbacks_t *(__cdecl *get_cli_shell_callbacks)(void);
+ 	} while(0)
+ 
+ #else
+-/*
+-#ifdef COMPILE_DL_READLINE
+-This dlsym() is always used as even the CGI SAPI is linked against "CLI"-only
+-extensions. If that is being changed dlsym() should only be used when building
+-this extension sharedto offer compatibility.
+-*/
+-#define GET_SHELL_CB(cb) \
+-	do { \
+-		(cb) = NULL; \
+-		cli_shell_callbacks_t *(*get_callbacks)(void); \
+-		get_callbacks = dlsym(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
+-		if (get_callbacks) { \
+-			(cb) = get_callbacks(); \
+-		} \
+-	} while(0)
+-/*#else
++
+ #define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()
+-#endif*/
++
+ #endif
+ 
+ PHP_MINIT_FUNCTION(cli_readline)
+-- 
+2.46.2
+

--- a/sync-source-code.php
+++ b/sync-source-code.php
@@ -115,6 +115,10 @@ PHP_OPCACHE_H_EOF
 
     cp -rf $SRC/ext/posix/ ./ext/posix
     cp -rf $SRC/ext/readline/ ./ext/readline
+    cp -f patches/0001-fix-readline-not-work.patch 0001-fix-readline-not-work.patch
+    git apply 0001-fix-readline-not-work.patch
+    exit 0
+    git apply 0001-fix-readline-not-work.patch
     cp -rf $SRC/ext/reflection/ ./ext/reflection
     cp -rf $SRC/ext/session/ ./ext/session
     cp -rf $SRC/ext/simplexml/ ./ext/simplexml

--- a/sync-source-code.php
+++ b/sync-source-code.php
@@ -168,7 +168,7 @@ PHP_OPCACHE_H_EOF
     cp -rf $SRC/sapi/cli/php.1.in ./sapi/cli
 
     # ext readline_cli patch
-    cp -f patches/0001-fix-readline-not-work.patch 0001-fix-readline-not-work.patch
+    cp -f sapi/patches/0001-fix-readline-not-work.patch 0001-fix-readline-not-work.patch
     { git apply --check 0001-fix-readline-not-work.patch ; } && { git apply 0001-fix-readline-not-work.patch ; }
 
 EOF;

--- a/sync-source-code.php
+++ b/sync-source-code.php
@@ -115,10 +115,6 @@ PHP_OPCACHE_H_EOF
 
     cp -rf $SRC/ext/posix/ ./ext/posix
     cp -rf $SRC/ext/readline/ ./ext/readline
-    cp -f patches/0001-fix-readline-not-work.patch 0001-fix-readline-not-work.patch
-    git apply 0001-fix-readline-not-work.patch
-    exit 0
-    git apply 0001-fix-readline-not-work.patch
     cp -rf $SRC/ext/reflection/ ./ext/reflection
     cp -rf $SRC/ext/session/ ./ext/session
     cp -rf $SRC/ext/simplexml/ ./ext/simplexml
@@ -166,12 +162,14 @@ PHP_OPCACHE_H_EOF
     sed -i.backup 's/int main(int argc, char \*argv\[\])/int fpm_main(int argc, char \*argv\[\])/g' ./sapi/cli/fpm/fpm_main.c
     sed -i.backup 's/{'-', 0, NULL}/{'P', 0, "fpm"},\n	{'-', 0, NULL}/g' ./sapi/cli/fpm/fpm_main.c
 
-
-
     # cli
     cp -rf $SRC/sapi/cli/ps_title.c ./sapi/cli
     cp -rf $SRC/sapi/cli/generate_mime_type_map.php ./sapi/cli
     cp -rf $SRC/sapi/cli/php.1.in ./sapi/cli
+
+    # ext readline_cli patch
+    cp -f patches/0001-fix-readline-not-work.patch 0001-fix-readline-not-work.patch
+    { git apply --check 0001-fix-readline-not-work.patch ; } && { git apply 0001-fix-readline-not-work.patch ; }
 
 EOF;
 


### PR DESCRIPTION
因为  `sync-source-code.php` 代码缺陷导致,导致[升级PHP源码](https://github.com/swoole/swoole-cli/commit/7a6319ecedbd08cabaf4421950c1a182537ba9f0) 出现 bug 

参照 [fix readline not work](https://github.com/swoole/swoole-cli/commit/0401aed2e5bb96e2affb6d209cc60fbabfa529bb#diff-796648a9b6c2460b3c37064323891656592e446ee721d7ed5652b5bc68307ea8R747)恢复