### PR TITLE
fix readline not work 2

### DIFF
--- a/ext/readline/readline_cli.c
+++ b/ext/readline/readline_cli.c
@@ -744,24 +744,8 @@ typedef cli_shell_callbacks_t *(__cdecl *get_cli_shell_callbacks)(void);
 	} while(0)
 
 #else
-/*
-#ifdef COMPILE_DL_READLINE
-This dlsym() is always used as even the CGI SAPI is linked against "CLI"-only
-extensions. If that is being changed dlsym() should only be used when building
-this extension sharedto offer compatibility.
-*/
-#define GET_SHELL_CB(cb) \
-	do { \
-		(cb) = NULL; \
-		cli_shell_callbacks_t *(*get_callbacks)(void); \
-		get_callbacks = dlsym(RTLD_DEFAULT, "php_cli_get_shell_callbacks"); \
-		if (get_callbacks) { \
-			(cb) = get_callbacks(); \
-		} \
-	} while(0)
-/*#else
 #define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()
-#endif*/
+  
 #endif
 
 PHP_MINIT_FUNCTION(cli_readline)

--- a/sapi/src/builder/extension/readline.php
+++ b/sapi/src/builder/extension/readline.php
@@ -11,4 +11,31 @@ return function (Preprocessor $p) {
             ->withOptions('--with-readline=' . READLINE_PREFIX)
             ->withDependentLibraries('ncurses', 'readline')
     );
+    // 扩展钩子
+    $p->withBeforeConfigureScript('readline', function (Preprocessor $p) {
+        $workDir = $p->getWorkDir();
+        $cmd = <<<EOF
+        cd {$workDir}/
+
+        FOUND_DL_READLINE=$(grep -c '#ifdef COMPILE_DL_READLINE' ext/readline/readline_cli.c)
+
+        if test $[FOUND_DL_READLINE] -gt 0 ; then
+            # 获得待删除 区间
+            START_LINE_NUM=$(sed  -n "/#ifdef COMPILE_DL_READLINE/=" ext/readline/readline_cli.c)
+            START_LINE_NUM=$((\$START_LINE_NUM - 1))
+            END_LINE_NUM=$(sed  -n "/PHP_MINIT_FUNCTION(cli_readline)/=" ext/readline/readline_cli.c)
+            END_LINE_NUM=$((\$END_LINE_NUM - 5))
+
+            sed -i.backup "\${START_LINE_NUM},\${END_LINE_NUM}d" ext/readline/readline_cli.c
+
+            REPLACE_LINE_NUM=$(sed  -n "/#define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()/=" ext/readline/readline_cli.c)
+            REPLACE_LINE_NUM=$((\$REPLACE_LINE_NUM + 1))
+
+            sed -i.backup "\${REPLACE_LINE_NUM} s/.*/  /" ext/readline/readline_cli.c
+
+        fi
+EOF;
+
+        return $cmd;
+    });
 };


### PR DESCRIPTION

使用 shell  
```shell

FOUND_DL_READLINE=$(grep -c '#ifdef COMPILE_DL_READLINE' ext/readline/readline_cli.c)

if test $[FOUND_DL_READLINE] -gt 0 ; then
    # 获得待删除 区间
    START_LINE_NUM=$(sed  -n "/#ifdef COMPILE_DL_READLINE/=" ext/readline/readline_cli.c)
    START_LINE_NUM=$(($START_LINE_NUM - 1))
    END_LINE_NUM=$(sed  -n "/PHP_MINIT_FUNCTION(cli_readline)/=" ext/readline/readline_cli.c)
    END_LINE_NUM=$(($END_LINE_NUM - 5))

    sed -i.backup "${START_LINE_NUM},${END_LINE_NUM}d" ext/readline/readline_cli.c

    REPLACE_LINE_NUM=$(sed  -n "/#define GET_SHELL_CB(cb) (cb) = php_cli_get_shell_callbacks()/=" ext/readline/readline_cli.c)
    REPLACE_LINE_NUM=$(($REPLACE_LINE_NUM + 1))

    sed -i.backup "${REPLACE_LINE_NUM} s/.*/  /" ext/readline/readline_cli.c

fi
```