### PR TITLE
修复 macos 环境下，启用 gettext 扩展 缺失依赖库 libintl

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -50,7 +50,7 @@
 | protobuf       | ❌     | ❌     | ❌               | ❌               |
 | uuid           | ✅     | ✅     | ❌               | ❌               |
 | mailparse      | ✅     | ✅     | ❌               | ❌               |
-| gettext        | ✅     | ❌     | ❌               | ❌               |
+| gettext        | ✅     | ✅     | ❌               | ❌               |
 | xslwriter      | ✅     | ✅     | ❌               | ✅               |
 
 ## 查看 新增的扩展 和 移除的扩展

--- a/sapi/src/Preprocessor.php
+++ b/sapi/src/Preprocessor.php
@@ -455,6 +455,18 @@ class Preprocessor
         return $this;
     }
 
+    protected array $frameworks = ['LDFLAGS' => []];
+
+    public function withFramework(string $key, string $value): static
+    {
+        if ($this->isMacos()) {
+            if (isset($this->frameworks[$key]) && !in_array($value, $this->frameworks[$key])) {
+                $this->frameworks[$key][] = $value;
+            }
+        }
+        return $this;
+    }
+
     public function getExtension(string $name): ?Extension
     {
         if (!isset($this->extensionMap[$name])) {

--- a/sapi/src/builder/enabled_extensions.php
+++ b/sapi/src/builder/enabled_extensions.php
@@ -37,5 +37,6 @@ return [
     'yaml',
     'imagick',
     'mongodb',
-    'xlswriter'
+    'xlswriter',
+    'gettext'
 ];

--- a/sapi/src/builder/library/gettext.php
+++ b/sapi/src/builder/library/gettext.php
@@ -6,50 +6,76 @@ use SwooleCli\Preprocessor;
 return function (Preprocessor $p) {
 
     // gettext 包含 libintl 库
-
+    //在常见的 Linux 发行版里，libintl 是由 libc 提供的，此时 gettext 编译的时候就不会附带 libintl；
+    //而如果在 macOS 上，由于 macOS 的 libc 没有 libintl 的 API，所以 gettext 编译的时候就要附带 libintl
+    //详情： https://jia.je/devops/2023/07/08/gentoo-prefix-m1/#libintl
     $gettext_prefix = GETTEXT_PREFIX;
     $libunistring_prefix = LIBUNISTRING_PREFIX;
     $iconv_prefix = ICONV_PREFIX;
     $libxml2_prefix = LIBXML2_PREFIX;
     $ncurses_prefix = NCURSES_PREFIX;
+    $options = '';
+    if ($p->isMacos()) {
+        $options .= ' --with-included-gettext ';
+    }
+
     $p->addLibrary(
         (new Library('gettext'))
             ->withHomePage('https://www.gnu.org/software/gettext/')
             ->withLicense('https://www.gnu.org/licenses/licenses.html', Library::LICENSE_GPL)
             ->withManual('https://www.gnu.org/software/gettext/')
-            //->withUrl('https://ftp.gnu.org/gnu/gettext/gettext-0.22.tar.xz')
-            ->withUrl('https://ftpmirror.gnu.org/gnu/gettext/gettext-0.22.tar.xz')
+            //->withUrl('https://ftp.gnu.org/gnu/gettext/gettext-0.22.5.tar.gz')
+            ->withUrl('https://ftpmirror.gnu.org/gettext/gettext-0.22.5.tar.gz')
+            ->withFileHash('sha256', "ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0")
             ->withPrefix($gettext_prefix)
+            //->withInstallCached(false)
             ->withConfigure(
                 <<<EOF
 
             ./configure --help
 
+            PACKAGES='zlib  '
+            PACKAGES="\$PACKAGES libxml-2.0"
+            PACKAGES="\$PACKAGES ncursesw"
+
+            CPPFLAGS="$(pkg-config  --cflags-only-I  --static \$PACKAGES) "
+            LDFLAGS="$(pkg-config   --libs-only-L    --static \$PACKAGES) "
+            LIBS="$(pkg-config      --libs-only-l    --static \$PACKAGES) "
+
+            CPPFLAGS="\${CPPFLAGS} -I{$libunistring_prefix}/include/ -I{$iconv_prefix}/include/"  \
+            LDFLAGS="\${LDFLAGS} -L{$libunistring_prefix}/lib/ -L{$iconv_prefix}/lib/" \
+            LIBS="\${LIBS} -liconv -lunistring " \
             ./configure \
             --prefix={$gettext_prefix} \
             --enable-shared=no \
             --enable-static=yes \
             --enable-relocatable \
             --enable-year2038 \
+            --with-pic \
             --with-libiconv-prefix={$iconv_prefix} \
             --with-libncurses-prefix={$ncurses_prefix} \
             --with-libxml2-prefix={$libxml2_prefix} \
             --with-libunistring-prefix={$libunistring_prefix} \
             --without-emacs \
             --without-lispdir \
-            --without-cvs \
             --disable-acl \
             --disable-java \
             --disable-csharp \
-            --without-git
+            --without-cvs \
+            --without-git \
+            --without-xz \
+            {$options} \
 
 
 EOF
             )
-            ->withDependentLibraries('libunistring', 'libiconv', 'ncurses', 'libxml2')
+            ->withDependentLibraries('libunistring', 'libiconv', 'ncurses', 'libxml2', 'zlib')
     );
 
     $p->withVariable('CPPFLAGS', '$CPPFLAGS -I' . $gettext_prefix . '/include');
     $p->withVariable('LDFLAGS', '$LDFLAGS -L' . $gettext_prefix . '/lib');
     $p->withVariable('LIBS', '$LIBS -lintl ');
+    if ($p->isMacos()) {
+        $p->withVariable('LDFLAGS', '$LDFLAGS -framework CoreFoundation ');
+    }
 };

--- a/sapi/src/builder/library/gettext.php
+++ b/sapi/src/builder/library/gettext.php
@@ -6,9 +6,9 @@ use SwooleCli\Preprocessor;
 return function (Preprocessor $p) {
 
     // gettext 包含 libintl 库
-    //在常见的 Linux 发行版里，libintl 是由 libc 提供的，此时 gettext 编译的时候就不会附带 libintl；
-    //而如果在 macOS 上，由于 macOS 的 libc 没有 libintl 的 API，所以 gettext 编译的时候就要附带 libintl
-    //详情： https://jia.je/devops/2023/07/08/gentoo-prefix-m1/#libintl
+    // 在常见的 Linux 发行版里，libintl 是由 libc 提供的，此时 gettext 编译的时候就不会附带 libintl；
+    // 而如果在 macOS 上，由于 macOS 的 libc 没有 libintl 的 API，所以 gettext 编译的时候就要附带 libintl
+    // 详情： https://jia.je/devops/2023/07/08/gentoo-prefix-m1/#libintl
     $gettext_prefix = GETTEXT_PREFIX;
     $libunistring_prefix = LIBUNISTRING_PREFIX;
     $iconv_prefix = ICONV_PREFIX;
@@ -24,11 +24,9 @@ return function (Preprocessor $p) {
             ->withHomePage('https://www.gnu.org/software/gettext/')
             ->withLicense('https://www.gnu.org/licenses/licenses.html', Library::LICENSE_GPL)
             ->withManual('https://www.gnu.org/software/gettext/')
-            //->withUrl('https://ftp.gnu.org/gnu/gettext/gettext-0.22.5.tar.gz')
             ->withUrl('https://ftpmirror.gnu.org/gettext/gettext-0.22.5.tar.gz')
             ->withFileHash('sha256', "ec1705b1e969b83a9f073144ec806151db88127f5e40fe5a94cb6c8fa48996a0")
             ->withPrefix($gettext_prefix)
-            //->withInstallCached(false)
             ->withConfigure(
                 <<<EOF
 
@@ -66,7 +64,6 @@ return function (Preprocessor $p) {
             --without-xz \
             {$options} \
 
-
 EOF
             )
             ->withDependentLibraries('libunistring', 'libiconv', 'ncurses', 'libxml2', 'zlib')
@@ -76,6 +73,6 @@ EOF
     $p->withVariable('LDFLAGS', '$LDFLAGS -L' . $gettext_prefix . '/lib');
     $p->withVariable('LIBS', '$LIBS -lintl ');
     if ($p->isMacos()) {
-        $p->withVariable('LDFLAGS', '$LDFLAGS -framework CoreFoundation ');
+        $p->withFramework('LDFLAGS', '-framework CoreFoundation');
     }
 };

--- a/sapi/src/template/make.php
+++ b/sapi/src/template/make.php
@@ -56,7 +56,7 @@ make_<?=$item->name?>() {
         mkdir -p <?= $this->getBuildDir() ?>/<?= $item->name . PHP_EOL ?>
         <?php if ($item->untarArchiveCommand == 'tar') : ?>
         tar --strip-components=1 -C <?= $this->getBuildDir() ?>/<?= $item->name ?> -xf <?= $this->workDir ?>/pool/lib/<?= $item->file ?>;
-        <?php elseif($item->untarArchiveCommand == 'unzip') :?>
+        <?php elseif ($item->untarArchiveCommand == 'unzip') :?>
         unzip -d  <?=$this->getBuildDir()?>/<?=$item->name?>   <?=$this->workDir?>/pool/lib/<?=$item->file ?>;
         <?php elseif ($item->untarArchiveCommand == 'tar-default') :?>
         tar  -C <?= $this->getBuildDir() ?>/<?= $item->name ?> -xf <?= $this->workDir ?>/pool/lib/<?= $item->file ?>;
@@ -198,7 +198,10 @@ export_variables() {
     export CPPFLAGS=$(echo $CPPFLAGS | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
     export LDFLAGS=$(echo $LDFLAGS | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
     export LIBS=$(echo $LIBS | tr ' ' '\n' | sort | uniq | tr '\n' ' ')
-
+<?php if ($this->isMacos() && !empty($this->frameworks['LDFLAGS'])):?>
+    # MACOS 链接 framework
+    export LDFLAGS="$LDFLAGS <?= implode(" ", $this->frameworks['LDFLAGS']) ?>"
+<?php endif; ?>
     result_code=$?
     [[ $result_code -ne 0 ]] &&  echo " [ export_variables  FAILURE ]" && exit  $result_code;
     set +x


### PR DESCRIPTION
gettext 包含 libintl 库
在常见的 Linux 发行版里，libintl 是由 libc 提供的，此时 gettext 编译的时候就不会附带 libintl；
而如果在 macOS 上，由于 macOS 的 libc 没有 libintl 的 API，所以 gettext 编译的时候就要附带 libintl
详情： https://jia.je/devops/2023/07/08/gentoo-prefix-m1/#libintl