### PR TITLE
修复 macos 环境下 libpq构建错误

### DIFF
--- a/sapi/src/builder/library/pgsql.php
+++ b/sapi/src/builder/library/pgsql.php
@@ -7,6 +7,13 @@ return function (Preprocessor $p) {
     $pgsql_prefix = PGSQL_PREFIX;
     $ldflags = $p->isMacos() ? '' : ' -static  ';
     $libs = $p->isMacos() ? '-lc++' : ' -lstdc++ ';
+
+    # fix macos error: 'strchrnul' is only available on macOS 15.4 or newer
+    # https://www.postgresql.org/message-id/385134.1743523038@sss.pgh.pa.us
+    # fix solution https://github.com/theory/pgenv/issues/93
+    $custom_env_start = $p->isMacos() ? 'export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion)"' : '';
+    $custom_env_end = $p->isMacos() ? 'unset MACOSX_DEPLOYMENT_TARGET' : '';
+
     $p->addLibrary(
         (new Library('pgsql'))
             ->withHomePage('https://www.postgresql.org/')
@@ -18,6 +25,7 @@ return function (Preprocessor $p) {
             ->withPrefix($pgsql_prefix)
             ->withBuildScript(
                 <<<EOF
+            {$custom_env_start}
             test -d build && rm -rf build
             mkdir -p build
             cd build
@@ -59,6 +67,7 @@ return function (Preprocessor $p) {
 
             make -C  src/interfaces/libpq install
 
+            {$custom_env_end}
 EOF
             )
             ->withScriptAfterInstall(


### PR DESCRIPTION
## 错误信息： 
```txt
error: 'strchrnul' is only available on macOS 15.4 or newer
```
[详情](https://github.com/swoole/swoole-cli/actions/runs/18895832056/job/53932930563#step:11:39295)
<img width="2778" height="1492" alt="268825d2-c080-42d7-9526-d481173fa5fd" src="https://github.com/user-attachments/assets/235e07c7-1397-4e7a-a3d4-68c9dfc76236" />




## 解决方案：
1. https://www.postgresql.org/message-id/385134.1743523038@sss.pgh.pa.us
1. https://github.com/theory/pgenv/issues/93

<img width="2292" height="1278" alt="0d0a0a0f-8422-441c-b71c-cb1174bcf34f" src="https://github.com/user-attachments/assets/6092e311-2000-49b3-9005-2c5cc4017ef6" />
<img width="2792" height="1520" alt="cc092730-fb36-41b2-a2f4-ca6e953a58fb" src="https://github.com/user-attachments/assets/2ffeb3a2-02ed-452e-87e6-c18452d18d28" />
