### PR TITLE
fix  no found pthread_barrier error on macos

### DIFF
--- a/sapi/src/builder/extension/swoole.php
+++ b/sapi/src/builder/extension/swoole.php
@@ -85,7 +85,8 @@ EOF;
         if ($p->isMacos()) {
             $extension_hook_shell = <<<EOF
         cd {$workDir}/
-        sed -i '' 's/pthread_barrier_init/pthread_barrier_init_x_fake/' ext/swoole/config.m4
+        sed -i.bak 's/pthread_barrier_init/pthread_barrier_init_x_fake/' ext/swoole/config.m4
+
 EOF;
         }
         return $shell . $extension_hook_shell;


### PR DESCRIPTION
## 错误信息
macos 环境下 构建时 检测 pthread_barrier_init 报错

## 查找是否存在 pthread_barrier
```shell
cd /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_pthread

grep -r 'pthread_barrier_init' .
grep -r 'pthread_barrier_t' .
```
## 解决方案
1. 屏蔽 pthread_barrier_init 检测


## 参考文档
1. https://www.google.com/search?q=macos++pthread_barrier&hl=en
2. https://stackoverflow.com/questions/76380942/osx-versions-with-pthread-barrier
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/aec5d02e-f86f-4023-ba94-a08926e311dc" />

macOS 和其底层 Darwin 操作系统本身并不原生支持pthread_barrier_init()
