### PR TITLE
解决 clone swoole 源码时，分支名称包含/，导致打包异常

### DIFF
--- a/sapi/src/builder/extension/swoole.php
+++ b/sapi/src/builder/extension/swoole.php
@@ -54,6 +54,8 @@ return function (Preprocessor $p) {
         $shell .= <<<'EOF'
 
         SWOOLE_VERSION=$(awk 'NR==1{ print $1 }' "sapi/SWOOLE-VERSION.conf")
+        ORIGIN_SWOOLE_VERSION=${SWOOLE_VERSION}
+        SWOOLE_VERSION=$(echo "${SWOOLE_VERSION}" | sed 's/[^a-zA-Z0-9]/_/g')
         CURRENT_SWOOLE_VERSION=''
 
         if [ -f "ext/swoole/CMakeLists.txt" ] ;then
@@ -71,7 +73,9 @@ return function (Preprocessor $p) {
             test -d ext/swoole && rm -rf ext/swoole
             if [ ! -f ${WORKDIR}/pool/ext/swoole-${SWOOLE_VERSION}.tgz ] ;then
                 test -d /tmp/swoole && rm -rf /tmp/swoole
-                git clone -b "${SWOOLE_VERSION}" https://github.com/swoole/swoole-src.git /tmp/swoole
+                git clone -b "${ORIGIN_SWOOLE_VERSION}" https://github.com/swoole/swoole-src.git /tmp/swoole
+                status=$?
+                if [[ $status -ne 0 ]]; then { echo $status ; exit 1 ; } fi
                 cd  /tmp/swoole
                 rm -rf /tmp/swoole/.git/
                 tar -czvf ${WORKDIR}/pool/ext/swoole-${SWOOLE_VERSION}.tgz .


### PR DESCRIPTION
当打包时,因tag名称的原因，导致打包异常
例子：
```
TAG="claude/swoole-http3-support-01J49VQEvNTSx4jud6fPwix3"
git clone -b  ${TAG} https://github.com/diyism/swoole-src.git

targ -czxvf swoole-${TAG}.tar.gz swoole-src
```

例子： 验证swoole 启用 http3  https://github.com/jingjingxyk/swoole-cli/pull/199/files
