### PR TITLE
Update libsodium.php

### DIFF
--- a/sapi/src/builder/library/libsodium.php
+++ b/sapi/src/builder/library/libsodium.php
@@ -9,7 +9,7 @@ return function (Preprocessor $p) {
             // ISC License, like BSD
             ->withLicense('https://en.wikipedia.org/wiki/ISC_license', Library::LICENSE_SPEC)
             ->withHomePage('https://doc.libsodium.org/')
-            ->withUrl('https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz')
+            ->withUrl('https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz')
             ->withFileHash('md5', '3ca9ebc13b6b4735acae0a6a4c4f9a95')
             ->withPrefix(LIBSODIUM_PREFIX)
             ->withConfigure('./configure --prefix=' . LIBSODIUM_PREFIX . ' --enable-static --disable-shared')


### PR DESCRIPTION
ibsodium下载地址更新  https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz   由于这个地址已经无法下载了，更新到github上的地址：  https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz