### PR TITLE
修复github macos runner 环境下 xlswriter 扩展构建错误

### DIFF
--- a/sapi/src/builder/enabled_extensions.php
+++ b/sapi/src/builder/enabled_extensions.php
@@ -37,6 +37,6 @@ return [
     'yaml',
     'imagick',
     'mongodb',
-//    'xlswriter',
+    'xlswriter',
     'gettext'
 ];

--- a/sapi/src/builder/extension/xlswriter.php
+++ b/sapi/src/builder/extension/xlswriter.php
@@ -14,4 +14,5 @@ return function (Preprocessor $p) {
             ->withOptions(' --with-xlswriter --enable-reader --with-openssl=' . OPENSSL_PREFIX)
             ->withDependentLibraries('openssl')
     );
+    $p->withVariable('CFLAGS', '$CFLAGS -std=gnu17');
 };


### PR DESCRIPTION
具体原因： macos-15 开始使用clang  c23标准作为默认构建环境
详见： [xlswriter](https://github.com/viest/php-ext-xlswriter/pull/560)
临时解决办法 指定 -std=gnu17 
等着 xlswriter 发布新版本 
